### PR TITLE
fix test teardown

### DIFF
--- a/tenant_schemas/tests/schemas.py
+++ b/tenant_schemas/tests/schemas.py
@@ -10,6 +10,7 @@ class SchemataTestCase(TransactionTestCase):
         Delete all tenant schemas. Tenant schema are not deleted
         automatically by django.
         """
+        connection.set_schema_to_public()
         do_not_delete = ['public', 'information_schema']
         cursor = connection.cursor()
         cursor.execute('SELECT schema_name FROM information_schema.schemata')


### PR DESCRIPTION
Teardown of db (destroy_test_db) may fail when our custom cursor
wrapper tries to set the search_path to a possibly already-deleted
schema.
