### PR TITLE
Add verbosity parameter to migrate_schemas after calling create_schema

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -53,6 +53,6 @@ class TenantMixin(models.Model):
 
             # fake all migrations
             if 'south' in settings.INSTALLED_APPS and not django_is_in_test_mode():
-                call_command('migrate_schemas', fake=True, schema_name=self.schema_name)
+                call_command('migrate_schemas', fake=True, schema_name=self.schema_name, verbosity=verbosity)
 
         return True


### PR DESCRIPTION
So you can call save(verbosity=0) without getting a lot of unexpected
messages
