### PR TITLE
Updated TenantClient and TenantRequestFactory

### DIFF
--- a/tenant_schemas/test/client.py
+++ b/tenant_schemas/test/client.py
@@ -12,9 +12,14 @@ class TenantRequestFactory(RequestFactory):
         if 'HTTP_HOST' not in extra:
             extra['HTTP_HOST'] = self.tenant.domain_url
 
-        request = super(TenantRequestFactory, self).get(path, data, **extra)
-        return self.tm.process_request(request)
+        return super(TenantRequestFactory, self).get(path, data, **extra)
+        
+    def post(self, path, data={}, **extra):
+        if 'HTTP_HOST' not in extra:
+            extra['HTTP_HOST'] = self.tenant.domain_url
 
+        return super(TenantRequestFactory, self).post(path, data, **extra)
+        
 
 class TenantClient(Client):
     tm = TenantMiddleware()


### PR DESCRIPTION
They were not working as expected. 
- The post() methods needed to be set to the tenant domain url the same as get().
- The request factory was processing the requests instead of returning them for use.
