### PR TITLE
Updated docs to address required tenant-specific Django contrib apps. 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -50,6 +50,11 @@ By default all apps will be synced to your `public` schema and to your tenant sc
     )
     
     TENANT_APPS = (
+	# The following Django contrib apps must be in TENANT_APPS
+	'django.contrib.auth',
+	'django.contrib.contenttypes',
+	'django.contrib.sites',
+
         # your tenant-specific apps
         'myapp.hotels',
         'myapp.houses', 


### PR DESCRIPTION
I found that at least these 3 Django contrib apps needed to be in the TENANT_APPS tuple in order to avoid the DatabaseError. Addresses ticket #4.
