### PR TITLE
South compatiblity issues

### DIFF
--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -103,14 +103,20 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
 
         self.pg_thread = PGThread()
 
-    def set_tenant(self, tenant, include_public=True):
+    def set_tenant(self, tenant, include_public = True):
+        self.set_settings_schema(tenant.schema_name)
         self.pg_thread.set_tenant(tenant, include_public)
 
-    def set_schema(self, schema_name, include_public=True):
+    def set_schema(self, schema_name, include_public = True):
+        self.set_settings_schema(schema_name)
         self.pg_thread.set_schema(schema_name, include_public)
 
     def set_schema_to_public(self):
+        self.set_settings_schema(get_public_schema_name())
         self.pg_thread.set_schema_to_public()
+
+    def set_settings_schema(self, schema_name):
+        self.settings_dict['SCHEMA'] = schema_name
 
     def get_schema(self):
         return self.pg_thread.get_schema()


### PR DESCRIPTION
Hello,

I'm having problems while using South to remove some unique constraints. It seems that South builds a constraints map through a query that is always relying on a specific fixed schema (public, in this case).

This problem was already reported in some time ago [here](http://south.aeracode.org/ticket/510) (south specific).

**The solution:** At first, South tries to check if `settings.DATABASES[<dbname>]` specifies a schema otherwise it will fallback to a default "public" schema. So I think we could set the database `SCHEMA` every time schemas swap, so South could rely on it.

I'm wondering in implementing this at `DatabaseWrapper` because it provides access to the settings through `self.settings_dict`. I made some tests and it works perfectly. It's a small change.

What do you think? Can I make a pull request?
