### PR TITLE
Check existence of PUBLIC_SCHEMA_URL_TOKEN before trying to access it.

### DIFF
--- a/tenant_schemas/utils.py
+++ b/tenant_schemas/utils.py
@@ -37,8 +37,9 @@ def clean_tenant_url(url_string):
     """
     Removes the TENANT_TOKEN from a particular string
     """
-    if settings.PUBLIC_SCHEMA_URL_TOKEN and url_string.startswith(settings.PUBLIC_SCHEMA_URL_TOKEN):
-        url_string = url_string[len(settings.PUBLIC_SCHEMA_URL_TOKEN):]
+    if hasattr(settings, 'PUBLIC_SCHEMA_URL_TOKEN'):
+        if settings.PUBLIC_SCHEMA_URL_TOKEN and url_string.startswith(settings.PUBLIC_SCHEMA_URL_TOKEN):
+            url_string = url_string[len(settings.PUBLIC_SCHEMA_URL_TOKEN):]
     return url_string
 
 


### PR DESCRIPTION
If using the tenant-schemas reverse method (or anything using clean_tenant_url), it should not assume PUBLIC_SCHEMA_URL_TOKEN is set. Throws AttributeError if not set.
