### PR TITLE
App labels now show up correctly if string is path to app.

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -59,7 +59,8 @@ class Command(NoArgsCommand):
                     ignored_apps.append(item)
 
         for app in ignored_apps:
-            settings.SOUTH_MIGRATION_MODULES[app] = 'ignore'
+            app_label = app.split('.')[-1]
+            settings.SOUTH_MIGRATION_MODULES[app_label] = 'ignore'
 
     def _save_south_settings(self):
         self._old_south_modules = None


### PR DESCRIPTION
When apps are specified in settings.py as a path, eg somepath.tothe.app or django.contrib.auth, they are unfit to be used in SOUTH_MIGRATION_MODULES. This setting calls for just the label of the app, not the path to it. See http://south.readthedocs.org/en/latest/settings.html#south-migration-modules.
