### PR TITLE
Added ability to use context managers if no tenant is set on connection.

### DIFF
--- a/tenant_schemas/utils.py
+++ b/tenant_schemas/utils.py
@@ -8,21 +8,29 @@ from django.core import mail
 @contextmanager
 def schema_context(schema_name):
     previous_tenant = connection.get_tenant()
+    previous_schema = connection.get_schema() if not previous_tenant else None
     try:
         connection.set_schema(schema_name)
         yield
     finally:
-        connection.set_tenant(previous_tenant)
+        if previous_tenant:
+            connection.set_tenant(previous_tenant)
+        else:
+            connection.set_schema(previous_schema)
 
 
 @contextmanager
 def tenant_context(tenant):
     previous_tenant = connection.get_tenant()
+    previous_schema = connection.get_schema() if not previous_tenant else None
     try:
         connection.set_tenant(tenant)
         yield
     finally:
-        connection.set_tenant(previous_tenant)
+        if previous_tenant:
+            connection.set_tenant(previous_tenant)
+        else:
+            connection.set_schema(previous_schema)
 
 
 def get_tenant_model():


### PR DESCRIPTION
If no tenant is set on the connection (e.g. after calling connection.set_schema_to_public()), then the schema_context and the tenant_context would raise an exception on exit. previous_tenant would be `None` in the finally blocks, and connection.set_tenant(None) would raise an AttributeError. The context managers no longer assume that a tenant is not None prior to entering the context.
