### PR TITLE
add template loaders looking for template based on the current tenant

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Contents
    install
    use
    examples
+   templates
    test
    involved
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1,0 +1,35 @@
+=======================================
+Specializing templates based on tenants
+=======================================
+
+Multitenant aware filesystem template loader
+--------------------------------------------
+
+The classical Django filesystem template loader cannot make the search path for template vary based on the current tenant so it's needed to use a special one which adapt the search path based on the tenant. For using it add it to your ``TEMPLATE_LOADERS`` setting.
+
+.. code-block:: python
+
+    TEMPLATE_LOADERS = (
+        'tenant_schemas.template_loaders.FilesystemLoader',
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader'
+    )
+
+This loader is looking for templates based on the setting ``MULTITENANT_TEMPLATE_DIRS`` instead of the path in ``TEMPLATE_DIRS``. Templates are not searched directly in each directory ``template_dir`` but in the directory ``os.path.join(template_dir, tenant.domain_url)``. Like with the Django ``FilesystemLoader`` the first found file is returned.
+
+Multitenant aware cached template loader
+----------------------------------------
+
+If you are using template caching with the multitenant filesystem loader it is not gonna work as the cache is ignoring the tenant. So the first template loaded for any tenant will be returned for all other tenants. To remediate to this problem you can use a new loader whose cache is based on the template path and the primary key of the tenant model.
+
+The multitenant cached loader works exactly like the Django cached loader but is tenant aware.
+
+.. code-block:: python
+
+    TEMPLATE_LOADERS = (
+        ('tenant_schemas.template_loaders.CachedLoader', (
+          'tenant_schemas.template_loaders.FilesystemLoader',
+          'django.template.loaders.filesystem.Loader',
+          'django.template.loaders.app_directories.Loader')),
+    )
+

--- a/tenant_schemas/template_loaders.py
+++ b/tenant_schemas/template_loaders.py
@@ -1,0 +1,115 @@
+"""
+Adaptations of the cached and filesystem template loader working in a
+multi-tenant setting
+"""
+
+import hashlib
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.template.base import TemplateDoesNotExist
+from django.template.loader import BaseLoader, get_template_from_string, find_template_loader, make_origin
+from django.utils.encoding import force_bytes
+from django.utils._os import safe_join
+from django.db import connection
+
+class CachedLoader(BaseLoader):
+    is_usable = True
+
+    def __init__(self, loaders):
+        self.template_cache = {}
+        self._loaders = loaders
+        self._cached_loaders = []
+
+    @property
+    def loaders(self):
+        # Resolve loaders on demand to avoid circular imports
+        if not self._cached_loaders:
+            # Set self._cached_loaders atomically. Otherwise, another thread
+            # could see an incomplete list. See #17303.
+            cached_loaders = []
+            for loader in self._loaders:
+                cached_loaders.append(find_template_loader(loader))
+            self._cached_loaders = cached_loaders
+        return self._cached_loaders
+
+    def find_template(self, name, dirs=None):
+        for loader in self.loaders:
+            try:
+                template, display_name = loader(name, dirs)
+                return (template, make_origin(display_name, loader, name, dirs))
+            except TemplateDoesNotExist:
+                pass
+        raise TemplateDoesNotExist(name)
+
+    def load_template(self, template_name, template_dirs=None):
+        if connection.tenant:
+            key = '-'.join([str(connection.tenant.pk), template_name])
+        else:
+            key = template_name
+        if template_dirs:
+            # If template directories were specified, use a hash to differentiate
+            if connection.tenant:
+                key = '-'.join([str(connection.tenant.pk), template_name, hashlib.sha1(force_bytes('|'.join(template_dirs))).hexdigest()])
+            else:
+                key = '-'.join([template_name, hashlib.sha1(force_bytes('|'.join(template_dirs))).hexdigest()])
+
+        if key not in self.template_cache:
+            template, origin = self.find_template(template_name, template_dirs)
+            if not hasattr(template, 'render'):
+                try:
+                    template = get_template_from_string(template, origin, template_name)
+                except TemplateDoesNotExist:
+                    # If compiling the template we found raises TemplateDoesNotExist,
+                    # back off to returning the source and display name for the template
+                    # we were asked to load. This allows for correct identification (later)
+                    # of the actual template that does not exist.
+                    return template, origin
+            self.template_cache[key] = template
+        return self.template_cache[key], None
+
+    def reset(self):
+        "Empty the template cache."
+        self.template_cache.clear()
+
+class FilesystemLoader(BaseLoader):
+    is_usable = True
+
+    def get_template_sources(self, template_name, template_dirs=None):
+        """
+        Returns the absolute paths to "template_name", when appended to each
+        directory in "template_dirs". Any paths that don't lie inside one of the
+        template dirs are excluded from the result set, for security reasons.
+        """
+        if not connection.tenant:
+            return
+        if not template_dirs:
+            try:
+                template_dirs = settings.MULTITENANT_TEMPLATE_DIRS
+            except AttributeError:
+                raise ImproperlyConfigured('To use %s.%s you must define the MULTITENANT_TEMPLATE_DIRS' % (__name__, FilesystemLoader.__name__))
+        for template_dir in template_dirs:
+            try:
+                yield safe_join(template_dir, connection.tenant.domain_url, template_name)
+            except UnicodeDecodeError:
+                # The template dir name was a bytestring that wasn't valid UTF-8.
+                raise
+            except ValueError:
+                # The joined path was located outside of this particular
+                # template_dir (it might be inside another one, so this isn't
+                # fatal).
+                pass
+
+    def load_template_source(self, template_name, template_dirs=None):
+        tried = []
+        for filepath in self.get_template_sources(template_name, template_dirs):
+            try:
+                with open(filepath, 'rb') as fp:
+                    return (fp.read().decode(settings.FILE_CHARSET), filepath)
+            except IOError:
+                tried.append(filepath)
+        if tried:
+            error_msg = "Tried %s" % tried
+        else:
+            error_msg = "Your TEMPLATE_DIRS setting is empty. Change it to point to at least one template directory."
+        raise TemplateDoesNotExist(error_msg)
+    load_template_source.is_usable = True


### PR DESCRIPTION
CachedLoader is similar to the django.template.loaders.cached.Loader but
it adds the tenant instance id to the key used for caching.

FilesystemLoader is similar to django.template.loaders.filesyste.Loader
but it uses the setting key MULTITENANT_TEMPLATE_DIRS instead of
TEMPLATE_DIRS and looks for template inside the directory
os.path.join(MULTITENANT_TEMPLATE_DIRS, tenant.domain_url).
