### PR TITLE
Do not try to set previous tenant if it is None.

### DIFF
--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 from tenant_schemas.utils import get_public_schema_name
+from tenant_schemas.utils import get_tenant_model
 
 ORIGINAL_BACKEND = getattr(settings, 'ORIGINAL_BACKEND', 'django.db.backends.postgresql_psycopg2')
 
@@ -42,7 +43,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         Main API method to current database schema,
         but it does not actually modify the db connection.
         """
-        self.tenant = None
+        self.tenant = get_tenant_model()(schema_name=schema_name)
         self.schema_name = schema_name
         self.include_public_schema = include_public
 
@@ -50,6 +51,8 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         """
         Instructs to stay in the common 'public' schema.
         """
+        # Can't get tenant model here because this is called
+        # from the __init__
         self.tenant = None
         self.schema_name = get_public_schema_name()
 

--- a/tenant_schemas/utils.py
+++ b/tenant_schemas/utils.py
@@ -12,7 +12,7 @@ def schema_context(schema_name):
         connection.set_schema(schema_name)
         yield
     finally:
-        if previous_tenant: connection.set_tenant(previous_tenant)
+        connection.set_tenant(previous_tenant)
 
 
 @contextmanager
@@ -22,7 +22,7 @@ def tenant_context(tenant):
         connection.set_tenant(tenant)
         yield
     finally:
-        if previous_tenant: connection.set_tenant(previous_tenant)
+        connection.set_tenant(previous_tenant)
 
 
 def get_tenant_model():


### PR DESCRIPTION
If previous tenant is None, there is error when trying to set it back.

This happens for example when it happens that schema is reseted to public when it is already public.
