### PR TITLE
Fixed issue with sync_schemas not recognising models in directory

### DIFF
--- a/tenant_schemas/management/commands/sync_schemas.py
+++ b/tenant_schemas/management/commands/sync_schemas.py
@@ -43,7 +43,7 @@ class Command(SyncCommon):
         verbosity = int(self.options.get('verbosity'))
         for app_model in get_apps():
             app_name = app_model.__name__.replace('.models', '')
-            if hasattr(app_model, 'models') and app_name in included_apps:
+            if app_name in included_apps:
                 for model in get_models(app_model, include_auto_created=True):
                     model._meta.managed = model._meta.was_managed
                     if model._meta.managed and verbosity >= 3:


### PR DESCRIPTION
The hasattr test was giving me problems with an app (Zinnia blog) which splits out its models into submodules - testing for the 'models' attribute on the models module fails in this instance, meaning the schemas don't get fully synced when a new tenant is set up.

I'm not sure what the original purpose of the test was but as far as I can tell get_apps() and get_models() appear to be sufficient to identify the models.
