### PR TITLE
Fix for migrating apps while syncing tables

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -82,7 +82,7 @@ class TenantMixin(models.Model):
                          tenant=True,
                          public=False,
                          interactive=False,  # don't ask to create an admin user
-                         migrate_all=fake_all_migrations,
+                         migrate_all=False,
                          verbosity=verbosity,
                          )
 


### PR DESCRIPTION
This was a bug when TENANT_CREATION_FAKES_MIGRATIONS was False.

When True (works as expected):
  `not fake_all_migrations == False` hence while calling sync_schemas
  apps with migrations would not be synced.
  Then migrate_schemas would execute with `fake_all_migrations == True`
  which would fake the migrations without creating tables.
  All good as expected!

When False (does not work as expected):
  `not fake_all_migrations == True` hence sync_schemas would
  create all the tables for apps with migrations.
  However for some strange reason, while creating
  tables, this does not actually migrate the models
  but instead just creates the appropriate tables.
  As a result, when migrate_schemas executes,
  it tries to recreate already created tables so
  things blow up.

To fix this, since `migrate_schemas` is always called after
`sync_schemas`, there is no reason to migrate anything while
executing `migrate_schemas`. Just always pass False
and let `migrate_schemas` migrate all apps with migrations
and it will properly fake migrations if it will needs to.
