### PR TITLE
Use old style indexing in format strings

### DIFF
--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -96,7 +96,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
             search_paths = [self.schema_name]
 
         search_paths.extend(EXTRA_SEARCH_PATHS)
-        cursor.execute('SET search_path = {}'.format(','.join(search_paths)))
+        cursor.execute('SET search_path = {0}'.format(','.join(search_paths)))
         return cursor
 
 


### PR DESCRIPTION
Unable to set search_path with Python 2.6 due to unindexed format string. Fixes #142
