### PR TITLE
Fix Migrations.all_migrations() list by clearing cache

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -30,6 +30,8 @@ class Command(SyncCommon):
         for app in ignored_apps:
             app_label = app.split('.')[-1]
             settings.SOUTH_MIGRATION_MODULES[app_label] = 'ignore'
+            
+        self._clear_south_cache()
 
     def _save_south_settings(self):
         self._old_south_modules = None


### PR DESCRIPTION
Creating Tenant using `TenantMixin` fails. `TenantMixin.create_schema` use `migrate_schemas` command. Command doesn't clear `Migrations` cache so `settings.SOUTH_MIGRATION_MODULES` filled with `'ignore'` values is ingnored by south Migrations. This cause use on tenant schema migrations also from shared schema.
Fix just clear south `Migrations` cache after changing `settings.SOUTH_MIGRATION_MODULES`.
Probably it can be done better, but this solve issue, and I think that place is intuitive.
