### PR TITLE
Working example of semi-public schemas.

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -19,6 +19,7 @@ class TenantMixin(models.Model):
 
     domain_url = models.CharField(max_length=128, unique=True)
     schema_name = models.CharField(max_length=63, unique=True)
+    additional_schemas = models.CharField(max_length=512, blank=True) # e.g. 'group1,salesinfo,group2'
 
     class Meta:
         abstract = True


### PR DESCRIPTION
# Semi-public schemas

This is a patch to add support for semi-public schemas to the django-tenant-schemas app. It may not be the most elegant solution and there is a to-do list before implementing this in the master branch. I modified the TenantMixin model to add the column 'additional_schemas' which is a string that will be added to PostgreSQL's search_path when queries are executed. This feature means that when implementing django-tenant-schemas add-on to legacy databases with data in schemas one can choose what tenants have access to those schemas on a database-level, isolating the data from tenant who should not have access to it.
## To-Do

*Add code to tenant-schemas/models.py save() function which detects schema name collision i.e. data-leaks (Example: tenants named tenant1 and tenant2, make sure that tenant2's additional_schemas string does not include the schema 'tenant1')
