### PR TITLE
This is bugfix that allow to run Tenant.save several times in one process

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -32,19 +32,26 @@ class Command(SyncCommon):
             settings.SOUTH_MIGRATION_MODULES[app_label] = 'ignore'
 
     def _save_south_settings(self):
-        self._old_south_modules = None
         if hasattr(settings, "SOUTH_MIGRATION_MODULES") and settings.SOUTH_MIGRATION_MODULES is not None:
             self._old_south_modules = settings.SOUTH_MIGRATION_MODULES.copy()
         else:
+            self._old_south_modules = None
             settings.SOUTH_MIGRATION_MODULES = dict()
 
     def _restore_south_settings(self):
-        settings.SOUTH_MIGRATION_MODULES = self._old_south_modules
+        if self._old_south_modules is None and hasattr(settings, "SOUTH_MIGRATION_MODULES"):
+            del settings.SOUTH_MIGRATION_MODULES
+        else:
+            settings.SOUTH_MIGRATION_MODULES = self._old_south_modules
 
     def _clear_south_cache(self):
         for mig in list(migration.all_migrations()):
             delattr(mig._application, "migrations")
         Migrations._clear_cache()
+        for mig in list(migration.all_migrations()):
+            for m in mig:
+                m.calculate_dependencies()
+            mig._dependencies_done = False
 
     def _migrate_schema(self, tenant):
         connection.set_tenant(tenant, include_public=False)


### PR DESCRIPTION
In fact this is bug fix for 3 different bugs that disallow to create many Tenant schemas in one process, for example in celery worker.

First bug occur when after migrating `SOUTH_MIGRATION_MODULES` is set to None, then next execution crash south, as it check only if `settings` `hasattr`, and not if it's proper `dict`.

Second bug is bug in south itself, they monkeypatch django `AppCache.get_apps` method, but it seems it's singleton object which methods must be properly restored. This was the hardest one to find.

Third bug is only in projects with migrations dependencies, caching is clearing to much or to less (it's matter of interpretation ;) ) and dependencies aren't computed after cleaning south migrations cache.
