### PR TITLE
Remove duplicated --schema option for tenant_command

### DIFF
--- a/tenant_schemas/management/commands/tenant_command.py
+++ b/tenant_schemas/management/commands/tenant_command.py
@@ -26,10 +26,6 @@ class Command(InteractiveTenantOption, BaseCommand):
         else:
             klass = load_command_class(app_name, argv[2])
 
-        self.option_list = klass.option_list + (
-            make_option("-s", "--schema", dest="schema_name", help="specify tenant schema"),
-        )
-
         super(Command, self).run_from_argv(argv)
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Maybe I misunderstand something, but it looks like '--schema' is added twice to option list for 'tenant_command' command line argument: first in  `management/commands/__init__.py` (in the constructor for InteractiveTenantOption) and then once again in `management/commands/tenant_command.py`.

This causes `optparse.OptionConflictError: option -s/--schema: conflicting option string(s): -s, --schema` on my machine while running basic `./manage.py tenant_command createsuperuser`.
