### PR TITLE
Allow to store templates in a subdirectory of a tenant directory

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -15,7 +15,7 @@ The classical Django filesystem template loader cannot make the search path for 
         'django.template.loaders.app_directories.Loader'
     )
 
-This loader is looking for templates based on the setting ``MULTITENANT_TEMPLATE_DIRS`` instead of the path in ``TEMPLATE_DIRS``. Templates are not searched directly in each directory ``template_dir`` but in the directory ``os.path.join(template_dir, tenant.domain_url)``. Like with the Django ``FilesystemLoader`` the first found file is returned.
+This loader is looking for templates based on the setting ``MULTITENANT_TEMPLATE_DIRS`` instead of the path in ``TEMPLATE_DIRS``. Templates are not searched directly in each directory ``template_dir`` but in the directory ``os.path.join(template_dir, tenant.domain_url)``. If ``template_dir`` contains a ``%s`` formatting placeholder the directory used is ``template_dir % tenant.domain_url`` so that you can store your templates in a subdirectory of your tenant directory. Like with the Django ``FilesystemLoader`` the first found file is returned.
 
 Multitenant aware cached template loader
 ----------------------------------------

--- a/tenant_schemas/template_loaders.py
+++ b/tenant_schemas/template_loaders.py
@@ -89,7 +89,10 @@ class FilesystemLoader(BaseLoader):
                 raise ImproperlyConfigured('To use %s.%s you must define the MULTITENANT_TEMPLATE_DIRS' % (__name__, FilesystemLoader.__name__))
         for template_dir in template_dirs:
             try:
-                yield safe_join(template_dir, connection.tenant.domain_url, template_name)
+                if '%s' in template_dir:
+                    yield safe_join(template_dir % connection.tenant.domain_url, template_name)
+                else:
+                    yield safe_join(template_dir, connection.tenant.domain_url, template_name)
             except UnicodeDecodeError:
                 # The template dir name was a bytestring that wasn't valid UTF-8.
                 raise


### PR DESCRIPTION
For example use MULTITENANT_TEMPLATE_DIRS =
('/var/lib/tenants/%s/templates/',) instead of just
('/var/lib/tenants/templates/',).
