### PR TITLE
Does not try to import south syncdb command if south is not in INSTALLED...

### DIFF
--- a/tenant_schemas/management/commands/syncdb.py
+++ b/tenant_schemas/management/commands/syncdb.py
@@ -2,9 +2,9 @@ from django.core.management.base import CommandError
 from django.conf import settings
 from tenant_schemas.utils import django_is_in_test_mode
 
-try:
+if 'south' in settings.INSTALLED_APPS:
     from south.management.commands import syncdb
-except ImportError:
+else:
     from django.core.management.commands import syncdb
 
 


### PR DESCRIPTION
..._APPS

If south is not really installed it breaks classic configuration since
the SOUTH_ADAPTER is not configured.
