### PR TITLE
Fix decode error for Python 3

### DIFF
--- a/version.py
+++ b/version.py
@@ -42,7 +42,7 @@ def call_git_describe():
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]
-        return line.strip()
+        return line.strip().decode('utf-8')
 
     except:
         return None
@@ -96,8 +96,7 @@ def get_git_version():
         write_release_version(version)
 
     # Finally, return the current version.
-
-    return version[1:].decode('utf-8')
+    return version[1:]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

`p.stdout.readlines()[0]` in `call_git_describe()` returns bytes object, which are not converted to a string object automatically in Python 3. Therefore, (for example) the string `b'v1.4.8'` will be saved to the VERSION file. After that, if the git repository is no longer available for some reason, `read_release_version()` will read the string `b'v1.4.8'` (and 'b' will be a character now!), and then `get_git_version()` will try to `decode()` it, which will lead to the error:

```
Traceback (most recent call last):
  File "version.py", line 104, in <module>
    print(get_git_version())
  File "version.py", line 100, in get_git_version
    return version[1:].decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```

The proposed patch decodes the bytes read from the pipe, so `call_git_describe()` will return unicode string for both Python 2 and Python 3.
