### PR TITLE
Fix minor Py3 issues

### DIFF
--- a/tenant_schemas/__init__.py
+++ b/tenant_schemas/__init__.py
@@ -11,13 +11,13 @@ This is necessary to overwrite built-in django management commands with their sc
 # Make a bunch of tests for configuration recommendations
 # These are best practices basically, to avoid hard to find bugs, unexpected behaviour
 if not hasattr(settings, 'TENANT_APPS'):
-    print ImproperlyConfigured('TENANT_APPS setting not set')
+    raise ImproperlyConfigured('TENANT_APPS setting not set')
 
 if not settings.TENANT_APPS:
     raise ImproperlyConfigured("TENANT_APPS is empty. Maybe you don't need this app?")
 
 if settings.INSTALLED_APPS[-1] != 'tenant_schemas':
-    print recommended_config
+    print(recommended_config)
 
 if hasattr(settings, 'PG_EXTRA_SEARCH_PATHS'):
     if get_public_schema_name() in settings.PG_EXTRA_SEARCH_PATHS:

--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -7,7 +7,7 @@ from tenant_schemas.utils import get_public_schema_name, get_limit_set_calls
 
 ORIGINAL_BACKEND = getattr(settings, 'ORIGINAL_BACKEND', 'django.db.backends.postgresql_psycopg2')
 
-original_backend = import_module('.base', ORIGINAL_BACKEND)
+original_backend = import_module(ORIGINAL_BACKEND + '.base')
 
 EXTRA_SEARCH_PATHS = getattr(settings, 'PG_EXTRA_SEARCH_PATHS', [])
 


### PR DESCRIPTION
Fix a couple of fixes that allows to run the module on Py3.

**About 'postgresql_backend/base.py':**
Before changing, I was getting the following error under Py3:

```
. . .
  File "C:\Python34\lib\importlib\__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "C:\Python34\lib\site-packages\django_tenant_schemas-1.4.8_3_g7e7f19a-py3.4.egg\tenant_schemas\postgresql_backend\base.py", line 11, in <module>
    original_backend = import_module('.base', ORIGINAL_BACKEND)
  File "C:\Python34\lib\importlib\__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2249, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2199, in _sanity_check
SystemError: Parent module 'django.db.backends.postgresql_psycopg2' not loaded, cannot perform relative import
```

Looks like Py3 does not import the second argument ('package') of `import_module` automatically, hence the errro. Here's what the doc says (https://docs.python.org/3.2/library/importlib.html?highlight=import_module#importlib.import_module): 

```
The import_module() function acts as a simplifying wrapper around importlib.__import__(). This means all
semantics of the function are derived from importlib.__import__(), including requiring the package from which
an import is occurring to have been previously imported (i.e., package must already be imported)
```
