### PR TITLE
Make schema_exists case insensitive

### DIFF
--- a/tenant_schemas/utils.py
+++ b/tenant_schemas/utils.py
@@ -78,7 +78,7 @@ def schema_exists(schema_name):
     cursor = connection.cursor()
 
     # check if this schema already exists in the db
-    sql = 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = %s)'
+    sql = 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_namespace WHERE LOWER(nspname) = LOWER(%s))'
     cursor.execute(sql, (schema_name, ))
 
     row = cursor.fetchone()


### PR DESCRIPTION
If a schema name contains uppercase characters then the schema won't be deleted even if `auto_drop_schema` is set to `True` (`schema_exists` will return `False`), because Postgres convert schema names to lowercase automatically.

This fix makes `schema_exists` case insensitive.
