### PR TITLE
Update MANIFEST and setup.py to use README.rst

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,13 @@
 
 include LICENSE
-include README.markdown
+include README.rst
 include *.txt
 
 include version.py
 include VERSION
 recursive-include docs *
 recursive-include examples *
+
+# exclude all bytecode
+global-exclude *.pyo
+global-exclude *.pyc

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url='https://github.com/bcarneiro/django-tenant-schemas',
     license='MIT',
     description='Tenant support for Django using PostgreSQL schemas.',
-    long_description=open('README.markdown').read() if exists("README.markdown") else "",
+    long_description=open('README.rst').read() if exists("README.rst") else "",
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Framework :: Django',


### PR DESCRIPTION
Fix to use new README.rst in MANIFEST and setup.py, also fix #186 by excluding bytecode files.
