### PR TITLE
Add database router allow_migrate() for Django 1.7

### DIFF
--- a/tenant_schemas/routers.py
+++ b/tenant_schemas/routers.py
@@ -7,7 +7,7 @@ class TenantSyncRouter(object):
     depending if we are syncing the shared apps or the tenant apps.
     """
 
-    def allow_syncdb(self, db, model):
+    def allow_migrate(self, db, model):
         # the imports below need to be done here else django <1.5 goes crazy
         # https://code.djangoproject.com/ticket/20704
         from django.db import connection
@@ -21,3 +21,7 @@ class TenantSyncRouter(object):
                 return False
 
         return None
+
+    def allow_syncdb(self, db, model):
+        # allow_syncdb was changed to allow_migrate in django 1.7
+        return self.allow_migrate(db, model)


### PR DESCRIPTION
From the Django 1.7 release notes:
> The allow_syncdb method on database routers is now called allow_migrate, but still performs the same function. Routers with allow_syncdb methods will still work, but that method name is deprecated and you should change it as soon as possible (nothing more than renaming is required).