### PR TITLE
Prevent template loader operating when FakeTenant is the active connecti...

### DIFF
--- a/tenant_schemas/template_loaders.py
+++ b/tenant_schemas/template_loaders.py
@@ -12,6 +12,7 @@ from django.template.loader import (BaseLoader, get_template_from_string,
 from django.utils.encoding import force_bytes
 from django.utils._os import safe_join
 from django.db import connection
+from tenant_schemas.postgresql_backend.base import FakeTenant
 
 
 class CachedLoader(BaseLoader):
@@ -85,7 +86,7 @@ class FilesystemLoader(BaseLoader):
         directory in "template_dirs". Any paths that don't lie inside one of the
         template dirs are excluded from the result set, for security reasons.
         """
-        if not connection.tenant:
+        if not connection.tenant or isinstance(connection.tenant, FakeTenant):
             return
         if not template_dirs:
             try:


### PR DESCRIPTION
...on.tenant

The `FakeTenant` does not have a `domain_url` attribute.

Alternative would be to set `domain_url`, but it seems more appropriate to bypass this loader for the `FakeTenant`.