### PR TITLE
Raise DisallowedHost instead of Http404

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,8 +29,10 @@ Add `tenant_schemas.routers.TenantSyncRouter` to your `DATABASE_ROUTERS` setting
     DATABASE_ROUTERS = (
         'tenant_schemas.routers.TenantSyncRouter',
     )
-    
-Add the middleware ``tenant_schemas.middleware.TenantMiddleware`` or ``tenant_schemas.middleware.SuspiciousTenantMiddleware`` to the top of ``MIDDLEWARE_CLASSES``, so that each request can be set to use the correct schema.
+
+Add the middleware ``tenant_schemas.middleware.TenantMiddleware`` to the top of ``MIDDLEWARE_CLASSES``, so that each request can be set to use the correct schema.
+
+If the hostname in the request does not match a valid tenant ``domain_url``, a HTTP 404 Not Found will be returned. If you'd like to raise ``DisallowedHost`` and a HTTP 400 response instead, use the ``tenant_schemas.middleware.SuspiciousTenantMiddleware``.
 
 .. code-block:: python
     

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,12 +30,13 @@ Add `tenant_schemas.routers.TenantSyncRouter` to your `DATABASE_ROUTERS` setting
         'tenant_schemas.routers.TenantSyncRouter',
     )
     
-Add the middleware ``tenant_schemas.middleware.TenantMiddleware`` to the top of ``MIDDLEWARE_CLASSES``, so that each request can be set to use the correct schema.
+Add the middleware ``tenant_schemas.middleware.TenantMiddleware`` or ``tenant_schemas.middleware.SuspiciousTenantMiddleware`` to the top of ``MIDDLEWARE_CLASSES``, so that each request can be set to use the correct schema.
 
 .. code-block:: python
     
     MIDDLEWARE_CLASSES = (
         'tenant_schemas.middleware.TenantMiddleware',
+        # 'tenant_schemas.middleware.SuspiciousTenantMiddleware',
         #...
     )
     

--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import DisallowedHost
 from django.db import connection
+from django.http import Http404
 from tenant_schemas.utils import (get_tenant_model, remove_www,
                                   get_public_schema_name)
 
@@ -12,6 +13,8 @@ class TenantMiddleware(object):
     Selects the proper database schema using the request host. Can fail in
     various ways which is better than corrupting or revealing data.
     """
+    TENANT_NOT_FOUND_EXCEPTION = Http404
+
     def hostname_from_request(self, request):
         """ Extracts hostname from request. Used for custom requests filtering.
             By default removes the request's port and common prefixes.
@@ -29,7 +32,8 @@ class TenantMiddleware(object):
             request.tenant = TenantModel.objects.get(domain_url=hostname)
             connection.set_tenant(request.tenant)
         except TenantModel.DoesNotExist:
-            raise DisallowedHost('No tenant for hostname "%s"' % hostname)
+            raise self.TENANT_NOT_FOUND_EXCEPTION(
+                'No tenant for hostname "%s"' % hostname)
 
         # Content type can no longer be cached as public and tenant schemas
         # have different models. If someone wants to change this, the cache
@@ -43,3 +47,16 @@ class TenantMiddleware(object):
         # Do we have a public-specific urlconf?
         if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():
             request.urlconf = settings.PUBLIC_SCHEMA_URLCONF
+
+
+class SuspiciousTenantMiddleware(TenantMiddleware):
+    """
+    Extend the TenantMiddleware in scenario where you need to configure
+    ``ALLOWED_HOSTS`` to allow ANY domain_url to be used because your tenants
+    can bring any custom domain with them, as opposed to all tenants being a
+    subdomain of a common base.
+
+    See https://github.com/bernardopires/django-tenant-schemas/pull/269 for
+    discussion on this middleware.
+    """
+    TENANT_NOT_FOUND_EXCEPTION = DisallowedHost

--- a/tenant_schemas/template_loaders.py
+++ b/tenant_schemas/template_loaders.py
@@ -12,6 +12,7 @@ from django.template.loader import (BaseLoader, get_template_from_string,
 from django.utils.encoding import force_bytes
 from django.utils._os import safe_join
 from django.db import connection
+from tenant_schemas.postgresql_backend.base import FakeTenant
 
 
 class CachedLoader(BaseLoader):
@@ -85,7 +86,7 @@ class FilesystemLoader(BaseLoader):
         directory in "template_dirs". Any paths that don't lie inside one of the
         template dirs are excluded from the result set, for security reasons.
         """
-        if not connection.tenant:
+        if not connection.tenant or isinstance(connection.tenant, FakeTenant):
             return
         if not template_dirs:
             try:


### PR DESCRIPTION
Treat an unknown tenant as though it were a request for a hostname not specified in `ALLOWED_HOSTS`.