### PR TITLE
Remove conflicting option "database" from SyncCommon

### DIFF
--- a/tenant_schemas/management/commands/__init__.py
+++ b/tenant_schemas/management/commands/__init__.py
@@ -138,8 +138,6 @@ class SyncCommon(BaseCommand):
         make_option('--migration_name', action='store', dest='migration_name', nargs='?',
                     help=('Database state will be brought to the state after that '
                           'migration. Use the name "zero" to unapply all migrations.')),
-        make_option('--database', action='store', dest='database', default=DEFAULT_DB_ALIAS,
-                    help='Nominates a database to synchronize. Defaults to the "default" database.'),
         make_option("-s", "--schema", dest="schema_name"),
     )
 


### PR DESCRIPTION
Fixes #272 