### PR TITLE
make migrate_schemas work for django 1.8

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -24,6 +24,11 @@ class MigrateSchemasCommand(SyncCommon):
         else:
             super(MigrateSchemasCommand, self).__init__()
 
+    def add_arguments(self, parser):
+        super(MigrateSchemasCommand, self).add_arguments(parser)
+        command = MigrateCommand()
+        command.add_arguments(parser)
+
     def handle(self, *args, **options):
         super(MigrateSchemasCommand, self).handle(*args, **options)
         self.PUBLIC_SCHEMA_NAME = get_public_schema_name()


### PR DESCRIPTION
Refactored code to meet new requirements of writing custom commands. https://docs.djangoproject.com/en/1.8/releases/1.8/#management-commands-that-only-accept-positional-arguments