### PR TITLE
Update allow_migrate() for Django 1.8. Fixes #231 (in 1.8)

### DIFF
--- a/tenant_schemas/routers.py
+++ b/tenant_schemas/routers.py
@@ -7,17 +7,21 @@ class TenantSyncRouter(object):
     depending if we are syncing the shared apps or the tenant apps.
     """
 
-    def allow_migrate(self, db, model):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
         # the imports below need to be done here else django <1.5 goes crazy
         # https://code.djangoproject.com/ticket/20704
         from django.db import connection
         from tenant_schemas.utils import get_public_schema_name, app_labels
 
+        if not isinstance(app_label, str):
+            # In django 1.7 the `app_label` parameter is actually `model`
+            app_label = app_label._meta.app_label
+
         if connection.schema_name == get_public_schema_name():
-            if model._meta.app_label not in app_labels(settings.SHARED_APPS):
+            if app_label not in app_labels(settings.SHARED_APPS):
                 return False
         else:
-            if model._meta.app_label not in app_labels(settings.TENANT_APPS):
+            if app_label not in app_labels(settings.TENANT_APPS):
                 return False
 
         return None


### PR DESCRIPTION
Django 1.8 will call it for RunPython and RunSQL operations, but we needed to update the method signature to opt-in. (those operations have no model)

See: https://docs.djangoproject.com/en/1.8/releases/1.8/#deprecated-signature-of-allow-migrate

I believe I've made it backwards compatible with 1.7 with lines 16-18, but since 1.7 will not check with `allow_migrate()` before running RunPython and RunSQL, 1.7 users will still need to employ the workaround in Issue #231.