### PR TITLE
Use tox to execute the test suite

### DIFF
--- a/docs/involved.rst
+++ b/docs/involved.rst
@@ -3,4 +3,4 @@ Get Involved!
 =============
 Suggestions, bugs, ideas, patches, questions
 --------------------------------------------
-Are **highly** welcome! Feel free to write an issue for any feedback you have or send a pull request on `GitHub <https://github.com/bernardopires/django-tenant-schemas>`. :)
+Are **highly** welcome! Feel free to write an issue for any feedback you have or send a pull request on `GitHub <https://github.com/bernardopires/django-tenant-schemas>`_. :)

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -9,6 +9,12 @@ If you're using South, don't forget to set ``SOUTH_TESTS_MIGRATE = False``. Run 
 
     ./manage.py test tenant_schemas.tests
 
+To run the test suite outsite of your application you can use tox_ to test all supported Django versions.
+
+.. code-block:: bash
+
+    tox
+
 Updating your app's tests to work with tenant-schemas
 -----------------------------------------------------
 Because django will not create tenants for you during your tests, we have packed some custom test cases and other utilities. If you want a test to happen at any of the tenant's domain, you can use the test case ``TenantTestCase``. It will automatically create a tenant for you, set the connection's schema to tenant's schema and make it available at ``self.tenant``. We have also included a ``TenantRequestFactory`` and a ``TenantClient`` so that your requests will all take place at the tenant's domain automatically. Here's an example
@@ -25,3 +31,5 @@ Because django will not create tenants for you during your tests, we have packed
         def test_user_profile_view(self):
             response = self.c.get(reverse('user_profile'))
             self.assertEqual(response.status_code, 200)
+
+.. _tox: https://tox.readthedocs.org/

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -75,10 +75,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'tenant_schemas.postgresql_backend',
         'NAME': 'dts_test_project',
-        'USER': 'postgres',
-        'PASSWORD': 'root',
-        'HOST': 'localhost',
-        'PORT': '',
+        'USER': os.environ.get('PG_USER', 'postgres'),
+        'PASSWORD': os.environ.get('PG_PASSWORD', 'root'),
+        'HOST': '127.0.0.1',
     }
 }
 

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -122,3 +122,34 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
+    },
+    'formatters': {
+        'simple': {
+            'format': '%(levelname)-7s %(asctime)s %(message)s',
+        },
+    },
+    'handlers': {
+        'null': {
+            'class': 'logging.NullHandler',
+        },
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['null'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}

--- a/tenant_schemas/tests/test_tenants.py
+++ b/tenant_schemas/tests/test_tenants.py
@@ -217,8 +217,12 @@ class TenantCommandTest(BaseTestCase):
         Tenant(domain_url='localhost', schema_name='public').save(verbosity=BaseTestCase.get_verbosity())
 
         out = StringIO()
-        call_command('tenant_command', 'dumpdata', 'tenant_schemas', natural_foreign=True,
-                     schema_name=get_public_schema_name(), stdout=out)
+        if django.VERSION >= (1, 8, 0):
+            call_command('tenant_command', args=('dumpdata', 'tenant_schemas'), natural_foreign=True,
+                         schema_name=get_public_schema_name(), stdout=out)
+        else:
+            call_command('tenant_command', 'dumpdata', 'tenant_schemas', natural_foreign=True,
+                         schema_name=get_public_schema_name(), stdout=out)
         self.assertItemsEqual(
             json.loads('[{"fields": {"domain_url": "localhost", "schema_name": "public"}, '
                        '"model": "tenant_schemas.tenant", "pk": 1}]'),

--- a/tenant_schemas/tests/testcases.py
+++ b/tenant_schemas/tests/testcases.py
@@ -39,7 +39,7 @@ class BaseTestCase(TestCase):
         for s in reversed(inspect.stack()):
             options = s[0].f_locals.get('options')
             if isinstance(options, dict):
-                return int(options['verbosity'])
+                return int(options['verbosity']) - 2
         return 1
 
     @classmethod

--- a/tenant_schemas/utils.py
+++ b/tenant_schemas/utils.py
@@ -1,12 +1,17 @@
+import logging
 from contextlib import contextmanager
+
 from django.conf import settings
 from django.db import connection
+
 try:
     from django.apps import apps
     get_model = apps.get_model
 except ImportError:
     from django.db.models.loading import get_model
 from django.core import mail
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -82,7 +87,9 @@ def django_is_in_test_mode():
     I know this is very ugly! I'm looking for more elegant solutions.
     See: http://stackoverflow.com/questions/6957016/detect-django-testing-mode
     """
-    return hasattr(mail, 'outbox')
+    in_test_mode = hasattr(mail, 'outbox')
+    logger.debug('TEST_MODE=%s', in_test_mode)
+    return in_test_mode
 
 
 def schema_exists(schema_name):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = py27-dj{17,18,19}
+
+[testenv]
+basepython =
+    py27: python2.7
+usedevelop = True
+
+deps =
+    dj17: Django~=1.7.0
+    dj18: Django~=1.8.0
+    dj19: Django~=1.9.0
+
+changedir = dts_test_project
+
+passenv = PG_USER PG_PASSWORD
+
+commands =
+    {envpython} manage.py test tenant_schemas.tests --noinput -v 2


### PR DESCRIPTION
I had difficulty in running the test suite for myself, so I decided to bootstrap it with tox to simplify it for contributors.

Additionally I updated the test settings.py to read the postgres username and password from the environment variables `PG_USER` and `PG_PASSWORD` respectively, as documented at https://codeship.com/documentation/databases/postgresql/#django, to demonstrate how we could use a CI pipeline.

To make the tests work with Django 1.8 and 1.9 I needed to add a conditional check to `TenantCommandTest.test_command ` and also tweaked the verbosity calculation in the `BaseTestCase` so you get output that doesn't spam the terminal unless you trigger it with `-v 2`.