### PR TITLE
Fixed the RemovedInDjango110Warning problem

### DIFF
--- a/examples/tenant_tutorial/tenant_tutorial/urls_public.py
+++ b/examples/tenant_tutorial/tenant_tutorial/urls_public.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from tenant_tutorial.views import HomeView
 
-urlpatterns = patterns('',
-                       url(r'^$', HomeView.as_view()),
-                       )
+urlpatterns = [
+    url(r'^$', HomeView.as_view()),
+]

--- a/examples/tenant_tutorial/tenant_tutorial/urls_tenants.py
+++ b/examples/tenant_tutorial/tenant_tutorial/urls_tenants.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from customers.views import TenantView
 
-urlpatterns = patterns('',
-                       url(r'^$', TenantView.as_view()),
-                       )
+urlpatterns = [
+    url(r'^$', TenantView.as_view()),
+]


### PR DESCRIPTION
Replaced django.conf.urls.patterns with a list of urls