### PR TITLE
fix `reverse` for Django 1.9

### DIFF
--- a/tenant_schemas/urlresolvers.py
+++ b/tenant_schemas/urlresolvers.py
@@ -1,5 +1,3 @@
-import warnings
-from django.conf import settings
 from django.core.urlresolvers import reverse as reverse_default
 from django.utils.functional import lazy
 from tenant_schemas.utils import clean_tenant_url

--- a/tenant_schemas/urlresolvers.py
+++ b/tenant_schemas/urlresolvers.py
@@ -6,7 +6,13 @@ from tenant_schemas.utils import clean_tenant_url
 
 
 def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
-    url = reverse_default(viewname, urlconf, args, kwargs, current_app)
+    url = reverse_default(
+        viewname=viewname, 
+        urlconf=urlconf, 
+        args=args, 
+        kwargs=kwargs, 
+        current_app=current_app
+    )
     return clean_tenant_url(url)
 
 reverse_lazy = lazy(reverse, str)

--- a/tenant_schemas/urlresolvers.py
+++ b/tenant_schemas/urlresolvers.py
@@ -5,7 +5,8 @@ from django.utils.functional import lazy
 from tenant_schemas.utils import clean_tenant_url
 
 
-def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
+def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
+            current_app=None):
     url = reverse_default(
         viewname=viewname, 
         urlconf=urlconf, 

--- a/tenant_schemas/urlresolvers.py
+++ b/tenant_schemas/urlresolvers.py
@@ -5,9 +5,8 @@ from django.utils.functional import lazy
 from tenant_schemas.utils import clean_tenant_url
 
 
-def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
-            current_app=None):
-    url = reverse_default(viewname, urlconf, args, kwargs, prefix, current_app)
+def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
+    url = reverse_default(viewname, urlconf, args, kwargs, current_app)
     return clean_tenant_url(url)
 
 reverse_lazy = lazy(reverse, str)


### PR DESCRIPTION
`reverse` no longer accepts the `prefix` argument
https://docs.djangoproject.com/en/1.9/ref/urlresolvers/#reverse