### PR TITLE
Single domain with multiple schemas #329

### DIFF
--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -1,10 +1,53 @@
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import DisallowedHost
+from django.core.exceptions import DisallowedHost, SuspiciousOperation
 from django.db import connection
 from django.http import Http404
 from tenant_schemas.utils import (get_tenant_model, remove_www,
                                   get_public_schema_name)
+
+
+class SchemaNameTenantMiddleware(object):
+    """
+    This middleware should be placed at the very top of the middleware stack.
+    Selects the proper database schema using the request host. Can fail in
+    various ways which is better than corrupting or revealing data.
+    """
+    TENANT_NOT_FOUND_EXCEPTION = Http404
+
+    @staticmethod
+    def schema_name_from_request(request):
+        try:
+            return request.META['HTTP_SCHEMANAME']
+        except KeyError:
+            raise SuspiciousOperation('Request header schemaname not provided')
+
+    def process_request(self, request):
+        # Connection needs first to be at the public schema, as this is where
+        # the tenant metadata is stored.
+        connection.set_schema_to_public()
+        schema_name = self.schema_name_from_request(request)
+
+        TenantModel = get_tenant_model()
+        try:
+            request.tenant = TenantModel.objects.get(schema_name=schema_name)
+            connection.set_tenant(request.tenant)
+        except TenantModel.DoesNotExist:
+            raise self.TENANT_NOT_FOUND_EXCEPTION(
+                'No tenant for schema name "%s"' % schema_name)
+
+        # Content type can no longer be cached as public and tenant schemas
+        # have different models. If someone wants to change this, the cache
+        # needs to be separated between public and shared schemas. If this
+        # cache isn't cleared, this can cause permission problems. For example,
+        # on public, a particular model has id 14, but on the tenants it has
+        # the id 15. if 14 is cached instead of 15, the permissions for the
+        # wrong model will be fetched.
+        ContentType.objects.clear_cache()
+
+        # Do we have a public-specific urlconf?
+        if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():
+            request.urlconf = settings.PUBLIC_SCHEMA_URLCONF
 
 
 class TenantMiddleware(object):

--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -10,7 +10,7 @@ from tenant_schemas.utils import (get_tenant_model, remove_www,
 class SchemaNameTenantMiddleware(object):
     """
     This middleware should be placed at the very top of the middleware stack.
-    Selects the proper database schema using the request host. Can fail in
+    Selects the proper database schema using the request header schemaname. Can fail in
     various ways which is better than corrupting or revealing data.
     """
     TENANT_NOT_FOUND_EXCEPTION = Http404


### PR DESCRIPTION
Hi.
As mentioned in Issue #329, I needed a way to find the correct schemas even though every request was made to the same domain.
To accomplish this, I have created a `SchemaNameTenantMiddleware` that extracts the header **schemaname** from the requests so we can set the correct schema (**if exists**).

`schema_name = self.schema_name_from_request(request)`

If this header is not present in the request, then I raise a **SuspiciousOperation** saying that the header was not provided.

```
def schema_name_from_request(request):
        try:
            return request.META['HTTP_SCHEMANAME']
        except KeyError:
            raise SuspiciousOperation('Request header schemaname not provided')
```

What do you think?

By the way, keep up the great job on this lib. It was really helpful.