### PR TITLE
Only send post_sync_signal on successful schema creation

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -50,12 +50,13 @@ class TenantMixin(models.Model):
         if is_new and self.auto_create_schema:
             try:
                 self.create_schema(check_if_exists=True, verbosity=verbosity)
-                post_schema_sync.send(sender=TenantMixin, tenant=self)
             except:
                 # We failed creating the tenant, delete what we created and
                 # re-raise the exception
                 self.delete(force_drop=True)
                 raise
+            else:
+                post_schema_sync.send(sender=TenantMixin, tenant=self)
 
     def delete(self, force_drop=False, *args, **kwargs):
         """


### PR DESCRIPTION
This avoids masking any errors that might happen in signal handlers.

This is related to #335 