### PR TITLE
migrate_schemas to support django 1.10

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -13,7 +13,7 @@ class Command(SyncCommon):
         """
         Changes the option_list to use the options from the wrapped migrate command.
         """
-        self.option_list += MigrateCommand.option_list
+        # self.option_list += MigrateCommand.option_list
         super(Command, self).__init__(stdout, stderr, no_color)
 
     def add_arguments(self, parser):


### PR DESCRIPTION
When I upgrade django to 1.10, I found the `migrate_schemas` command cannot be used. From the point of error information, django 1.10 has been removed `option_list`. So I comment out this line of code to make this command  can run normally temporary.