### PR TITLE
fix compatibility issues with Django 1.10

### DIFF
--- a/tenant_schemas/management/commands/migrate_schemas.py
+++ b/tenant_schemas/management/commands/migrate_schemas.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.core.management.commands.migrate import Command as MigrateCommand
 from django.db import connection
+import django
+
 
 from tenant_schemas.management.commands import SyncCommon
 from tenant_schemas.utils import get_tenant_model, get_public_schema_name, schema_exists
@@ -13,7 +15,8 @@ class Command(SyncCommon):
         """
         Changes the option_list to use the options from the wrapped migrate command.
         """
-        self.option_list += MigrateCommand.option_list
+        if django.VERSION <= (1,10,0):
+            self.option_list += MigrateCommand.option_list
         super(Command, self).__init__(stdout, stderr, no_color)
 
     def add_arguments(self, parser):

--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -5,9 +5,10 @@ from django.db import connection
 from django.http import Http404
 from tenant_schemas.utils import (get_tenant_model, remove_www,
                                   get_public_schema_name)
+from django.utils.deprecation import MiddlewareMixin
 
 
-class TenantMiddleware(object):
+class TenantMiddleware(MiddlewareMixin):
     """
     This middleware should be placed at the very top of the middleware stack.
     Selects the proper database schema using the request host. Can fail in


### PR DESCRIPTION
this commit fixes two issues impacting compatibility with django 1.10
* The migrate_schemas issue identified here: https://github.com/bernardopires/django-tenant-schemas/pull/371
* compatibility with Django's new style of middleware: https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware

