### PR TITLE
Removed quotes from username value for createsuperuser command

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -111,7 +111,7 @@ The command ``createsuperuser`` is already automatically wrapped to have a ``sch
 
 .. code-block:: bash
 
-    ./manage.py createsuperuser --username='admin' --schema=customer1
+    ./manage.py createsuperuser --username=admin --schema=customer1
 
 
 list_tenants


### PR DESCRIPTION
I was following the documentation and since I never used `--username` with `createsuperuser` before, I entered my username by wrapping it in single quotes. It wasted an hour of my time and I was pulling my hair because I was unable to login no matter how many accounts I created.

I later realized that the single quotes were actually treated as part of the username instead of it treated like a string. I mean my username was literally `'admin'` and not `admin`.