### PR TITLE
Document a position on supported versions of Django & PostgreSQL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-tenant-schemas
 =====================
 
-|PyPi version| |PyPi downloads| |Travis CI|
+|PyPi version| |PyPi downloads| |Python versions| |Travis CI| |PostgreSQL|
 
 This application enables `django`_ powered websites to have multiple
 tenants via `PostgreSQL schemas`_. A vital feature for every
@@ -204,7 +204,9 @@ tenant specific apps. Complete instructions can be found at
    :target: https://pypi.python.org/pypi/django-tenant-schemas
 .. |PyPi downloads| image:: https://img.shields.io/pypi/dm/django-tenant-schemas.svg
    :target: https://pypi.python.org/pypi/django-tenant-schemas
+.. |Python versions| image:: https://img.shields.io/pypi/pyversions/django-tenant-schemas.svg
 .. |Travis CI| image:: https://travis-ci.org/bernardopires/django-tenant-schemas.svg?branch=master
    :target: https://travis-ci.org/bernardopires/django-tenant-schemas
+.. |PostgreSQL| image:: https://img.shields.io/badge/PostgreSQL-9.2%2C%209.3%2C%209.4%2C%209.5%2C%209.6-blue.svg
 .. _setup: https://django-tenant-schemas.readthedocs.io/en/latest/install.html
 .. _django-tenant-schemas.readthedocs.io: https://django-tenant-schemas.readthedocs.io/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 Welcome to django-tenant-schemas documentation!
 ===============================================
-This application enables `Django <https://www.djangoproject.com/>`_ powered websites to have multiple tenants via `PostgreSQL schemas <http://www.postgresql.org/docs/9.1/static/ddl-schemas.html>`_. A vital feature for every Software-as-a-Service website.
+This application enables `Django <https://www.djangoproject.com/>`_ powered websites to have multiple tenants via `PostgreSQL schemas <http://www.postgresql.org/docs/9.2/static/ddl-schemas.html>`_. A vital feature for every Software-as-a-Service website.
 
 Django provides currently no simple way to support multiple tenants using the same project instance, even when only the data is different. Because we don't want you running many copies of your project, you'll be able to have:
 
@@ -10,7 +10,7 @@ Django provides currently no simple way to support multiple tenants using the sa
 
 What are schemas?
 -----------------
-A schema can be seen as a directory in an operating system, each directory (schema) with it's own set of files (tables and objects). This allows the same table name and objects to be used in different schemas without conflict. For an accurate description on schemas, see `PostgreSQL's official documentation on schemas <http://www.postgresql.org/docs/9.1/static/ddl-schemas.html>`_.
+A schema can be seen as a directory in an operating system, each directory (schema) with it's own set of files (tables and objects). This allows the same table name and objects to be used in different schemas without conflict. For an accurate description on schemas, see `PostgreSQL's official documentation on schemas <http://www.postgresql.org/docs/9.2/static/ddl-schemas.html>`_.
 
 Why schemas?
 ------------

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -1,6 +1,12 @@
 ===========================
 Using django-tenant-schemas
 ===========================
+Supported versions
+------------------
+You can use ``django-tenant-schemas`` with currently maintained versions of Django -- see the `Django's release process <https://docs.djangoproject.com/en/1.10/internals/release-process/>`_ and the present list of `Supported Versions <https://www.djangoproject.com/download/#supported-versions>`_.
+
+It is necessary to use a PostgreSQL database. ``django-tenant-schemas`` will ensure compatibility with the minimum required version of the latest Django release. At this time that is PostgreSQL 9.2, the minimum for Django 1.10.
+
 Creating a Tenant
 -----------------
 Creating a tenant works just like any other model in django. The first thing we should do is to create the ``public`` tenant to make our main website available. We'll use the previous model we defined for ``Client``.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,14 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
         'Programming Language :: Python',
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Topic :: Database",
+        "Topic :: Software Development :: Libraries",
     ],
     install_requires=[
         'Django >= 1.8.0',


### PR DESCRIPTION
Across the three versions of Django that django-tenant-schemas tries to support, there are three minimum versions of PostgreSQL.

- [Django 1.8](https://docs.djangoproject.com/en/1.8/ref/databases/#postgresql-notes) ~= PostgreSQL 9.0
- [Django 1.9](https://docs.djangoproject.com/en/1.9/ref/databases/#postgresql-notes) ~= PostgreSQL 9.1
- [Django 1.10](https://docs.djangoproject.com/en/1.10/ref/databases/#postgresql-notes) ~= PostgreSQL 9.2

Running the tests against PostgreSQL version 9.1 returns the following error (for each permutation in the tox environment list)

    ERROR:  invalid value for parameter "search_path": "test, public"
    DETAIL:  schema "test" does not exist
    STATEMENT:  SET search_path = test,public
    ERROR:  invalid value for parameter "search_path": "tenant1, public"
    DETAIL:  schema "tenant1" does not exist
    STATEMENT:  SET search_path = tenant1,public
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SET search_path = tenant1,public
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SAVEPOINT "s140735883977664_x217"
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SET search_path = tenant1,public
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SAVEPOINT "s140735883977664_x218"
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SET search_path = tenant1,public
    ERROR:  current transaction is aborted, commands ignored until end of transaction block
    STATEMENT:  SAVEPOINT "s140735883977664_x219"

Django 1.10 does not support PostgreSQL 9.1, but 1.8 and 1.9 do, so I was surprised when none of the combinations worked against that version.

Rather than try to continually patch for prehistoric versions in this little project, I've made a documentation suggestion that declares a position for "supported versions".

The short form:

- support all versions of Django as the Django project does
- support the minimum version of PostgreSQL that the latest Django release does

Thoughts?