### PR TITLE
Configure so that packages are pushed to PyPI on tags to master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,12 @@ env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+
+deploy:
+  provider: pypi
+  user: bcarneiro
+  password: fixme
+  on:
+    tags: true
+    distributions: sdist
+    repo: bernardopires/django-tenant-schemas


### PR DESCRIPTION
Related to #410 this will perform automated releases to PyPI from Travis CI simply by tagging and pushing (assuming the tests still pass, of course).

Still requires @bernardopires to perform the following step prior to merging:

    travis encrypt --add deploy.password

See the Travis CI documentation on [PyPI deployment](https://docs.travis-ci.com/user/deployment/pypi/) for all possible options, but I think this is what we want.