### PR TITLE
#430 - Check wether tenant_schemas comes before any django apps instead of before all apps.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,7 +82,7 @@ To make use of shared and tenant-specific applications, there are two settings c
 .. code-block:: python
     
     SHARED_APPS = (
-        'tenant_schemas',  # mandatory
+        'tenant_schemas',  # mandatory, should always be before any django app
         'customers', # you must list the app where your tenant model resides in
         
         'django.contrib.contenttypes',

--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -42,7 +42,8 @@ def best_practice(app_configs, **kwargs):
 
     errors = []
 
-    if INSTALLED_APPS[0] != 'tenant_schemas':
+    django_index = next(i for i, s in enumerate(INSTALLED_APPS) if 'django.' in s)
+    if INSTALLED_APPS.index('tenant_schemas') > django_index:
         errors.append(
             Warning("You should put 'tenant_schemas' first in INSTALLED_APPS.",
                     obj="django.conf.settings",

--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -42,10 +42,11 @@ def best_practice(app_configs, **kwargs):
 
     errors = []
 
-    django_index = next(i for i, s in enumerate(INSTALLED_APPS) if 'django.' in s)
+    django_index = next(i for i, s in enumerate(INSTALLED_APPS) if s.startswith('django.'))
     if INSTALLED_APPS.index('tenant_schemas') > django_index:
         errors.append(
-            Warning("You should put 'tenant_schemas' first in INSTALLED_APPS.",
+            Warning("You should put 'tenant_schemas' before any django "
+                    "core applications in INSTALLED_APPS.",
                     obj="django.conf.settings",
                     hint="This is necessary to overwrite built-in django "
                          "management commands with their schema-aware "

--- a/tenant_schemas/tests/test_apps.py
+++ b/tenant_schemas/tests/test_apps.py
@@ -56,7 +56,7 @@ class AppConfigTests(TestCase):
         'django.contrib.messages',
         'django.contrib.staticfiles',
     ])
-    def test_tenant_schemas_last_installed_apps(self):
+    def test_tenant_schemas_before_django_installed_apps(self):
         self.assertBestPractice([
             Warning("You should put 'tenant_schemas' first in INSTALLED_APPS.",
                     obj="django.conf.settings",
@@ -64,6 +64,19 @@ class AppConfigTests(TestCase):
                          "management commands with their schema-aware "
                          "implementations."),
         ])
+
+    @override_settings(INSTALLED_APPS=[
+        'dts_test_app',
+        'customers',
+        'tenant_schemas',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.messages',
+        'django.contrib.staticfiles',
+    ])
+    def test_tenant_schemas_after_custom_apps_in_installed_apps(self):
+        self.assertBestPractice([])
 
     @override_settings(TENANT_APPS=())
     def test_tenant_apps_empty(self):

--- a/tenant_schemas/tests/test_apps.py
+++ b/tenant_schemas/tests/test_apps.py
@@ -58,7 +58,8 @@ class AppConfigTests(TestCase):
     ])
     def test_tenant_schemas_before_django_installed_apps(self):
         self.assertBestPractice([
-            Warning("You should put 'tenant_schemas' first in INSTALLED_APPS.",
+            Warning("You should put 'tenant_schemas' before any django "
+                    "core applications in INSTALLED_APPS.",
                     obj="django.conf.settings",
                     hint="This is necessary to overwrite built-in django "
                          "management commands with their schema-aware "


### PR DESCRIPTION
This fixes issue #430, where if people would like to override tenant_schemas commands then can do so with their own apps. Right now tenant_schemas won't work if any other app is placed before it. This change takes care of that.