### PR TITLE
Issue 443

### DIFF
--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -93,6 +93,14 @@ def best_practice(app_configs, **kwargs):
                   hint=[a for a in settings.SHARED_APPS if a in delta],
                   id="tenant_schemas.E003"))
 
+    installed_not_shared_or_tenant = set(INSTALLED_APPS).difference(
+        set(settings.SHARED_APPS).union(settings.TENANT_APPS))
+    if installed_not_shared_or_tenant:
+        errors.append(
+            Error("You have INSTALLED_APPS that are not in either of "
+                  "TENANT_APPS or SHARED_APPS",
+                  hint=sorted(installed_not_shared_or_tenant)))
+
     if not isinstance(default_storage, TenantStorageMixin):
         errors.append(Warning(
             "Your default storage engine is not tenant aware.",

--- a/tenant_schemas/tests/test_apps.py
+++ b/tenant_schemas/tests/test_apps.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.core.checks import Critical, Error, Warning
 from django.test import TestCase
-from django.test.utils import override_settings
+from django.test.utils import modify_settings, override_settings
 
 from tenant_schemas.apps import best_practice
 from tenant_schemas.utils import get_tenant_model
@@ -118,16 +118,9 @@ class AppConfigTests(TestCase):
                   id="tenant_schemas.E002"),
         ])
 
-    @override_settings(SHARED_APPS=(
-        'tenant_schemas',
-        'customers',
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.flatpages',
-        'django.contrib.messages',
-        'django.contrib.sessions',
-        'django.contrib.staticfiles',
-    ))
+    @modify_settings(SHARED_APPS={
+        'append': 'django.contrib.flatpages',
+    })
     def test_shared_app_missing_from_install_apps(self):
         self.assertBestPractice([
             Error("You have SHARED_APPS that are not in INSTALLED_APPS",
@@ -135,17 +128,9 @@ class AppConfigTests(TestCase):
                   id="tenant_schemas.E003"),
         ])
 
-    @override_settings(INSTALLED_APPS=(
-        'tenant_schemas',
-        'dts_test_app',
-        'customers',
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.humanize',
-        'django.contrib.messages',
-        'django.contrib.sessions',
-        'django.contrib.staticfiles',
-    ))
+    @modify_settings(INSTALLED_APPS={
+        'append': 'django.contrib.humanize',
+    })
     def test_installed_app_missing_from_shared_and_tenant_apps(self):
         self.assertBestPractice([
             Error("You have INSTALLED_APPS that are not in either of "

--- a/tenant_schemas/tests/test_apps.py
+++ b/tenant_schemas/tests/test_apps.py
@@ -86,6 +86,9 @@ class AppConfigTests(TestCase):
             Error("TENANT_APPS is empty.",
                   hint="Maybe you don't need this app?",
                   id="tenant_schemas.E001"),
+            Error("You have INSTALLED_APPS that are not in either of "
+                  "TENANT_APPS or SHARED_APPS",
+                  hint=['dts_test_app']),
         ])
 
     @override_settings(PG_EXTRA_SEARCH_PATHS=['public', 'demo1', 'demo2'])
@@ -100,11 +103,20 @@ class AppConfigTests(TestCase):
             Critical("Do not include tenant schemas (demo1, demo2) on PG_EXTRA_SEARCH_PATHS."),
         ])
 
-    @override_settings(SHARED_APPS=())
+    @override_settings(SHARED_APPS=(), INSTALLED_APPS=(
+        'tenant_schemas',
+        'dts_test_app',
+        'django.contrib.contenttypes',
+    ))
+    @modify_settings(TENANT_APPS={
+        'append': 'django.contrib.contenttypes',
+    })
     def test_shared_apps_empty(self):
         self.assertBestPractice([
-            Warning("SHARED_APPS is empty.",
-                    id="tenant_schemas.W002"),
+            Warning("SHARED_APPS is empty.", id="tenant_schemas.W002"),
+            Error("You have INSTALLED_APPS that are not in either of "
+                  "TENANT_APPS or SHARED_APPS",
+                  hint=['tenant_schemas']),
         ])
 
     @override_settings(TENANT_APPS=(

--- a/tenant_schemas/tests/test_apps.py
+++ b/tenant_schemas/tests/test_apps.py
@@ -134,3 +134,21 @@ class AppConfigTests(TestCase):
                   hint=['django.contrib.flatpages'],
                   id="tenant_schemas.E003"),
         ])
+
+    @override_settings(INSTALLED_APPS=(
+        'tenant_schemas',
+        'dts_test_app',
+        'customers',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.humanize',
+        'django.contrib.messages',
+        'django.contrib.sessions',
+        'django.contrib.staticfiles',
+    ))
+    def test_installed_app_missing_from_shared_and_tenant_apps(self):
+        self.assertBestPractice([
+            Error("You have INSTALLED_APPS that are not in either of "
+                  "TENANT_APPS or SHARED_APPS",
+                  hint=['django.contrib.humanize']),
+        ])


### PR DESCRIPTION
Add system check to raise an error if any application is declared in the `INSTALLED_APPS` but is missing from both of `SHARED_APPS` and `TENANT_APPS`.

Fixes #443.