### PR TITLE
Modifying tenant instance in testcases

### DIFF
--- a/docs/test.rst
+++ b/docs/test.rst
@@ -43,4 +43,20 @@ Running tests using ``TenantTestCase`` can start being a bottleneck once the num
     from tenant_schemas.test.cases import FastTenantTestCase
 
 
+Updating TestCase for more complicated tenant
+---------------------------------------------
+
+If you set your tenant to not automatically create schema by setting ``auto_create_schema = False`` or if you have some fields that have to be filled for the tenant, you can override the provided ``TenantTestCase`` or ``FastTenantTestCase`` and implement the class method ``modify_tenant_instance`` with all the updates you need. Here's a example for tenant which doesn't create schemas automatically and has to have a name set up.
+
+.. code-block:: python
+
+    from tenant_schemas.test import cases
+
+    class TenantTestCase(cases.TenantTestCase):
+        @classmethod
+        def modify_tenant_instace(cls):
+            cls.auto_create_schema = True
+            cls.name = "Name of the tenant"
+
+
 .. _tox: https://tox.readthedocs.io/

--- a/tenant_schemas/test/cases.py
+++ b/tenant_schemas/test/cases.py
@@ -9,6 +9,13 @@ ALLOWED_TEST_DOMAIN = '.test.com'
 
 class TenantTestCase(TestCase):
     @classmethod
+    def modify_tenant_instance(cls):
+        """ Allows modifications of tenant for all tests, e.g. to set `auto_create_schema` to True
+            or to set required attributes of the model.
+        """
+        pass
+
+    @classmethod
     def add_allowed_test_domain(cls):
         # ALLOWED_HOSTS is a special setting of Django setup_test_environment so we can't modify it with helpers
         if ALLOWED_TEST_DOMAIN not in settings.ALLOWED_HOSTS:
@@ -25,6 +32,7 @@ class TenantTestCase(TestCase):
         cls.add_allowed_test_domain()
         tenant_domain = 'tenant.test.com'
         cls.tenant = get_tenant_model()(domain_url=tenant_domain, schema_name='test')
+        cls.modify_tenant_instance()
         cls.tenant.save(verbosity=0)  # todo: is there any way to get the verbosity from the test command here?
 
         connection.set_tenant(cls.tenant)
@@ -58,6 +66,7 @@ class FastTenantTestCase(TenantTestCase):
             cls.tenant = TenantModel.objects.get(domain_url=tenant_domain, schema_name='test')
         except:
             cls.tenant = TenantModel(domain_url=tenant_domain, schema_name='test')
+            cls.modify_tenant_instance()
             cls.tenant.save(verbosity=0)
 
         connection.set_tenant(cls.tenant)


### PR DESCRIPTION
Added a modify_tenant_instance class method to testcases which allows for modifications of the tenant when needed.

This fixes the issue in #425, when user setups the tenant with ``auto_create_schema = False`` they can fix the testcases with a simple modification that's shown in the documentation for the method.

However it can do more - the creation of the tenant can fail on other things - for example columns in the database which can't be null and have no default value setup. This method also allows for that to be fixed as well. (I think that's the problem in #438)