### PR TITLE
Fix CachedLoader when template_dirs is None

### DIFF
--- a/tenant_schemas/template_loaders.py
+++ b/tenant_schemas/template_loaders.py
@@ -38,7 +38,9 @@ class CachedLoader(BaseLoader):
 
     @staticmethod
     def cache_key(template_name, template_dirs):
-        if connection.tenant and template_dirs:
+        if connection.tenant:
+            if not template_dirs:
+                template_dirs = settings.MULTITENANT_TEMPLATE_DIRS
             return '-'.join([str(connection.tenant.pk), template_name,
                              hashlib.sha1(force_bytes('|'.join(template_dirs))).hexdigest()])
         if template_dirs:


### PR DESCRIPTION
From Django 1.10 onwards, `template_dirs` isn't passed while getting the template: https://github.com/django/django/blob/1.10/django/template/engine.py#L155. This causes multi tenant template cache to fail as the cache key is dependent on template_dirs.