### PR TITLE
Fix ContentType clear_cache() to always happen at a schema change

### DIFF
--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -62,15 +62,6 @@ class BaseTenantMiddleware(MIDDLEWARE_MIXIN):
         request.tenant = tenant
         connection.set_tenant(request.tenant)
 
-        # Content type can no longer be cached as public and tenant schemas
-        # have different models. If someone wants to change this, the cache
-        # needs to be separated between public and shared schemas. If this
-        # cache isn't cleared, this can cause permission problems. For example,
-        # on public, a particular model has id 14, but on the tenants it has
-        # the id 15. if 14 is cached instead of 15, the permissions for the
-        # wrong model will be fetched.
-        ContentType.objects.clear_cache()
-
         # Do we have a public-specific urlconf?
         if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():
             request.urlconf = settings.PUBLIC_SCHEMA_URLCONF

--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -67,11 +67,8 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         Main API method to current database schema,
         but it does not actually modify the db connection.
         """
+        self.set_schema(tenant.schema_name, include_public)
         self.tenant = tenant
-        self.schema_name = tenant.schema_name
-        self.include_public_schema = include_public
-        self.set_settings_schema(self.schema_name)
-        self.search_path_set = False
 
     def set_schema(self, schema_name, include_public=True):
         """

--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -88,10 +88,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         """
         Instructs to stay in the common 'public' schema.
         """
-        self.tenant = FakeTenant(schema_name=get_public_schema_name())
-        self.schema_name = get_public_schema_name()
-        self.set_settings_schema(self.schema_name)
-        self.search_path_set = False
+        self.set_schema(get_public_schema_name())
 
     def set_settings_schema(self, schema_name):
         self.settings_dict['SCHEMA'] = schema_name

--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -3,6 +3,7 @@ import warnings
 import psycopg2
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 import django.db.utils
 
@@ -80,6 +81,14 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         self.include_public_schema = include_public
         self.set_settings_schema(schema_name)
         self.search_path_set = False
+        # Content type can no longer be cached as public and tenant schemas
+        # have different models. If someone wants to change this, the cache
+        # needs to be separated between public and shared schemas. If this
+        # cache isn't cleared, this can cause permission problems. For example,
+        # on public, a particular model has id 14, but on the tenants it has
+        # the id 15. if 14 is cached instead of 15, the permissions for the
+        # wrong model will be fetched.
+        ContentType.objects.clear_cache()
 
     def set_schema_to_public(self):
         """


### PR DESCRIPTION
Right now the ContentType cache is only cleared at the beginning of a request via the call from the middleware. However, anything that uses "with schema_context" or calls set_tenant() or set_schema() should also force a ContentType clear_cache() call. By moving it down to the database wrapper it will always happen on a schema change. Because set_tenant() is called in the middleware, it will also still happen at the same time it was called before (beginning of a request).