### PR TITLE
backported django postgres backend fixes

### DIFF
--- a/dts_test_project/dts_test_app/migrations/0003_test_add_db_index.py
+++ b/dts_test_project/dts_test_app/migrations/0003_test_add_db_index.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dts_test_app', '0002_test_drop_unique'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='DummyModel',
+            name='indexed_value',
+            field=models.CharField(max_length=255, db_index=True),
+        ),
+    ]

--- a/dts_test_project/dts_test_app/migrations/0004_test_alter_unique.py
+++ b/dts_test_project/dts_test_app/migrations/0004_test_alter_unique.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dts_test_app', '0003_test_add_db_index'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='DummyModel',
+            name='indexed_value',
+            field=models.CharField(max_length=255, unique=True),
+        ),
+
+        migrations.RemoveField(
+            model_name='DummyModel',
+            name='indexed_value',
+        ),
+    ]


### PR DESCRIPTION
There has been several fixes in Postgres introspection recently :
- https://github.com/django/django/commit/566726ff964b004f2a6adecc1e51197bc34d78d2#diff-7f14932a08ce1dbba14da7433e47f9fc
- https://github.com/django/django/commit/e585c43be91fb3e5005ddb4191f64142c62a2ec3#diff-7f14932a08ce1dbba14da7433e47f9fc
- https://github.com/django/django/commit/2f6cdc09c4db46ad13ff736b93a975bcd587abf4#diff-7f14932a08ce1dbba14da7433e47f9fc

(see [commits](https://github.com/django/django/commits/stable/1.11.x/django/db/backends/postgresql/introspection.py) and [file](https://github.com/django/django/blob/stable/1.11.x/django/db/backends/postgresql/introspection.py), and [django issue](https://code.djangoproject.com/ticket/26034))

The diff here is thus a copy-paste of django queries, plus some minor python updates.

I got into this after an encounter with a migration issue in https://github.com/jazzband/django-oauth-toolkit, when applying [this migration](https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/migrations/0004_auto_20160525_1623.py): each column was switched from ```db_index=True``` to ```unique=True```. There weren't any problems with Django 1.10.x and Django 1.11, but I ran into this issue for Django >= 1.11.1 and the aforementioned changes in Django:
```bash
======================================================================
ERROR: test_public_schema_on_extra_search_paths (tenant_schemas.tests.test_apps.AppConfigTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/test/utils.py", line 384, in inner
    return func(*args, **kwargs)
  File "/home/vagrant/code/dts/tenant_schemas/tests/test_apps.py", line 95, in test_public_schema_on_extra_search_paths
    schema_name='demo1', domain_url='demo1.example.com')
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/models/query.py", line 394, in create
    obj.save(force_insert=True, using=self.db)
  File "/home/vagrant/code/dts/tenant_schemas/models.py", line 71, in save
    self.create_schema(check_if_exists=True, verbosity=verbosity)
  File "/home/vagrant/code/dts/tenant_schemas/models.py", line 118, in create_schema
    verbosity=verbosity)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 131, in call_command
    return command.execute(*args, **defaults)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/code/dts/tenant_schemas/management/commands/migrate_schemas.py", line 53, in handle
    executor.run_migrations(tenants=tenants)
  File "/home/vagrant/code/dts/tenant_schemas/migration_executors/base.py", line 61, in run_migrations
    self.run_tenant_migrations(tenants)
  File "/home/vagrant/code/dts/tenant_schemas/migration_executors/standard.py", line 9, in run_tenant_migrations
    run_migrations(self.args, self.options, self.codename, schema_name)
  File "/home/vagrant/code/dts/tenant_schemas/migration_executors/base.py", line 31, in run_migrations
    MigrateCommand(stdout=stdout, stderr=stderr).execute(*args, **options)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 204, in handle
    fake_initial=fake_initial,
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 115, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 145, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 244, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/migrations/migration.py", line 129, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/migrations/operations/fields.py", line 221, in database_forwards
    schema_editor.alter_field(from_model, from_field, to_field)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 515, in alter_field
    old_db_params, new_db_params, strict)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/backends/postgresql/schema.py", line 119, in _alter_field
    self.execute(like_index_statement)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 120, in execute
    cursor.execute(sql, params)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/vagrant/code/dts/.tox/py27-dj111-standard/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
ProgrammingError: relation "dts_test_app_dummymodel_indexed_value_730a47c4_like" already exists
```

This error is obtained by running the tests without my modifications but with the newly added migrations (0003 and 0004).

Cheers