### PR TITLE
Remove tenant schema PG_EXTRA_SEARCH_PATHS check

### DIFF
--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -66,14 +66,6 @@ def best_practice(app_configs, **kwargs):
                 "%s can not be included on PG_EXTRA_SEARCH_PATHS."
                 % get_public_schema_name()))
 
-        # make sure no tenant schema is in settings.PG_EXTRA_SEARCH_PATHS
-        invalid_schemas = set(settings.PG_EXTRA_SEARCH_PATHS).intersection(
-            get_tenant_model().objects.all().values_list('schema_name', flat=True))
-        if invalid_schemas:
-            errors.append(Critical(
-                "Do not include tenant schemas (%s) on PG_EXTRA_SEARCH_PATHS."
-                % ", ".join(sorted(invalid_schemas))))
-
     if not settings.SHARED_APPS:
         errors.append(
             Warning("SHARED_APPS is empty.",


### PR DESCRIPTION
This is currently making it impossible to perform migrations on a blank
database with PG_EXTRA_SEARCH_PATHS set. see issue #450.