### PR TITLE
System checks of INSTALLED_APPS

### DIFF
--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -19,12 +19,7 @@ def best_practice(app_configs, **kwargs):
     if app_configs is None:
         app_configs = apps.get_app_configs()
 
-    # Take the app_configs and turn them into *old style* application names.
-    # This is what we expect in the SHARED_APPS and TENANT_APPS settings.
-    INSTALLED_APPS = [
-        config.name
-        for config in app_configs
-    ]
+    INSTALLED_APPS = settings.INSTALLED_APPS
 
     if not hasattr(settings, 'TENANT_APPS'):
         return [Critical('TENANT_APPS setting not set')]


### PR DESCRIPTION
Fixes #443 
The system check `best_practice` gets a list of INSTALLED_APPS from the `app_configs` parameter but then it compares it with `settings.SHARED_APPS` and `settings.TENANT_APPS`. I changed it so that it also uses `settings.INSTALLED_APPS` instead of using the `app_configs` parameter.

We had to change this to be able to use Sentry. Sentry's Django AppConfig's name is "raven.contrib.django", but in INSTALLED_APPS (according to [the docs](https://raven.readthedocs.io/en/stable/integrations/django.html)) you write "raven.contrib.django.raven_compat".

There's probably a problem in the way the Raven app is configured, since its `AppConfig.name` should be the full Python path to the app. But I also think that this fix in `django-tenant-schemas` is in order.

What do you think?