### PR TITLE
Add support for using run_syncdb in unit tests on tenant schemas

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -53,7 +53,7 @@ class TenantMixin(models.Model):
     class Meta:
         abstract = True
 
-    def save(self, verbosity=1, *args, **kwargs):
+    def save(self, verbosity=1, run_syncdb=False, *args, **kwargs):
         is_new = self.pk is None
 
         if is_new and connection.schema_name != get_public_schema_name():
@@ -68,7 +68,7 @@ class TenantMixin(models.Model):
 
         if is_new and self.auto_create_schema:
             try:
-                self.create_schema(check_if_exists=True, verbosity=verbosity)
+                self.create_schema(check_if_exists=True, verbosity=verbosity, run_syncdb=run_syncdb)
             except:
                 # We failed creating the tenant, delete what we created and
                 # re-raise the exception
@@ -94,7 +94,7 @@ class TenantMixin(models.Model):
         return super(TenantMixin, self).delete(*args, **kwargs)
 
     def create_schema(self, check_if_exists=False, sync_schema=True,
-                      verbosity=1):
+                      verbosity=1, run_syncdb=False):
         """
         Creates the schema 'schema_name' for this tenant. Optionally checks if
         the schema already exists before creating it. Returns true if the
@@ -115,6 +115,7 @@ class TenantMixin(models.Model):
             call_command('migrate_schemas',
                          schema_name=self.schema_name,
                          interactive=False,
-                         verbosity=verbosity)
+                         verbosity=verbosity,
+                         run_syncdb=run_syncdb)
 
         connection.set_schema_to_public()

--- a/tenant_schemas/test/cases.py
+++ b/tenant_schemas/test/cases.py
@@ -25,7 +25,7 @@ class TenantTestCase(TestCase):
         cls.add_allowed_test_domain()
         tenant_domain = 'tenant.test.com'
         cls.tenant = get_tenant_model()(domain_url=tenant_domain, schema_name='test')
-        cls.tenant.save(verbosity=0)  # todo: is there any way to get the verbosity from the test command here?
+        cls.tenant.save(verbosity=0, run_syncdb=True)  # todo: is there any way to get the verbosity from the test command here?
 
         connection.set_tenant(cls.tenant)
 
@@ -58,7 +58,7 @@ class FastTenantTestCase(TenantTestCase):
             cls.tenant = TenantModel.objects.get(domain_url=tenant_domain, schema_name='test')
         except:
             cls.tenant = TenantModel(domain_url=tenant_domain, schema_name='test')
-            cls.tenant.save(verbosity=0)
+            cls.tenant.save(verbosity=0, run_syncdb=True)
 
         connection.set_tenant(cls.tenant)
 


### PR DESCRIPTION
When using django-tenant-schemas with Django 1.8, pytest-django works when using [--no-migrations](http://pytest-django.readthedocs.io/en/latest/database.html#nomigrations-disable-django-1-7-migrations).

When upgrading to Django 1.10, existing tests for my project no longer work with _--no-migrations_, resulting in tests that take much longer to run.

The issue is Django 1.9 added the _--run-syncdb_ option to the [migrate](https://docs.djangoproject.com/en/1.9/ref/django-admin/#django-admin-migrate) command, which defaults to _False_. Looking at the [migrate source code](https://github.com/django/django/blob/1.10.1/django/core/management/commands/migrate.py#L137), the _--no-migrations_ functionality requires _run_syncdb_ to be _True_ in order to work correctly.