### PR TITLE
Support non-auto-incrementing ids for Tenant model

### DIFF
--- a/tenant_schemas/models.py
+++ b/tenant_schemas/models.py
@@ -54,7 +54,7 @@ class TenantMixin(models.Model):
         abstract = True
 
     def save(self, verbosity=1, *args, **kwargs):
-        is_new = self.pk is None
+        is_new = self._state.adding
 
         if is_new and connection.schema_name != get_public_schema_name():
             raise Exception("Can't create tenant outside the public schema. "


### PR DESCRIPTION
If you use non-incrementing ids (like UUIDs) for models, then checking `instance.pk` no longer properly indicates whether the instance has been saved. Instead we can use `instance._state.adding`

Let me know if there are any updates to documentation or tests that you'd like to see before considering this Pull Request.