### PR TITLE
Handle multiple tenant-aware database connections

### DIFF
--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -3,10 +3,10 @@ import django
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import DisallowedHost
-from django.db import connection
 from django.http import Http404
 from tenant_schemas.utils import (get_tenant_model, remove_www,
-                                  get_public_schema_name)
+                                  get_public_schema_name, set_tenant,
+                                  set_schema_to_public)
 
 if django.VERSION >= (1, 10, 0):
     MIDDLEWARE_MIXIN = django.utils.deprecation.MiddlewareMixin
@@ -43,7 +43,7 @@ class BaseTenantMiddleware(MIDDLEWARE_MIXIN):
     def process_request(self, request):
         # Connection needs first to be at the public schema, as this is where
         # the tenant metadata is stored.
-        connection.set_schema_to_public()
+        set_schema_to_public()
 
         hostname = self.hostname_from_request(request)
         TenantModel = get_tenant_model()
@@ -60,7 +60,7 @@ class BaseTenantMiddleware(MIDDLEWARE_MIXIN):
                 'Invalid tenant {!r}'.format(request.tenant))
 
         request.tenant = tenant
-        connection.set_tenant(request.tenant)
+        set_tenant(request.tenant)
 
         # Do we have a public-specific urlconf?
         if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():


### PR DESCRIPTION
I have some special requirements that cause me to have multiple defined database connections to the same tenant schemas (just with different postgres users). For this to work out properly, I had to beef up some of the method in utils.py to operate on `django.db.connections` instead of `django.db.connection`. 

I tried to make sure that the updates are backwards compatible, but am open fixing anything I may have missed.

Let me know if there are any updates to documentation or tests that you'd like to see before considering this Pull Request. I'm assuming you'd want some documentation updates to cover the updated utils behavior.