### PR TITLE
Support the UserModel living in the Shared Schema (for createsuperuser Command)

### DIFF
--- a/tenant_schemas/management/commands/createsuperuser.py
+++ b/tenant_schemas/management/commands/createsuperuser.py
@@ -1,6 +1,14 @@
+from django.contrib.auth import get_user_model
 from tenant_schemas.management.commands import TenantWrappedCommand
 from django.contrib.auth.management.commands import createsuperuser
+from django.conf import settings
 
 
-class Command(TenantWrappedCommand):
+class WrappedCommand(TenantWrappedCommand):
     COMMAND = createsuperuser.Command
+
+
+user_model_in_shared_schema = get_user_model()._meta.app_label in settings.SHARED_APPS
+
+Command = createsuperuser.Command if user_model_in_shared_schema else WrappedCommand
+


### PR DESCRIPTION
In order to support a special requirement I have that the superusers should exist in the shared schema, I had to make a small change to the overridden createsuperuser Command. Now it only overrides the django-defined version if the UserModel isn't in the `settings.SHARED_APPS` registry.