### PR TITLE
Add schemacontext and tenantcontext template tags.

### DIFF
--- a/tenant_schemas/templatetags/tenant.py
+++ b/tenant_schemas/templatetags/tenant.py
@@ -1,8 +1,8 @@
-from django.template import Library
+from django import template
 from django.template.defaulttags import url as default_url, URLNode
-from tenant_schemas.utils import clean_tenant_url
+from tenant_schemas.utils import clean_tenant_url, schema_context, tenant_context
 
-register = Library()
+register = template.Library()
 
 
 class SchemaURLNode(URLNode):
@@ -17,3 +17,63 @@ class SchemaURLNode(URLNode):
 @register.tag
 def url(parser, token):
     return SchemaURLNode(default_url(parser, token))
+
+
+@register.tag
+def schemacontext(parser, token):
+    try:
+        tag_name, schema_name_arg = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError(
+            '%r tag requires exactly one argument' % token.contents.split()[0]
+        )
+    nodelist = parser.parse(('endschemacontext',))
+    parser.delete_first_token()
+    return SchemaContextNode(schema_name_arg, nodelist)
+
+
+class SchemaContextNode(template.Node):
+    def __init__(self, schema_name_arg, nodelist):
+        self.schema_name_arg = template.Variable(schema_name_arg)
+        self.nodelist = nodelist
+
+    def render(self, context):
+        try:
+            schema_name = self.schema_name_arg.resolve(context)
+        except template.VariableDoesNotExist:
+            raise template.TemplateSyntaxError(
+                'Unable to resolve %r' % self.schema_name_arg.var
+            )
+        with schema_context(schema_name):
+            output = self.nodelist.render(context)
+        return output
+
+
+@register.tag
+def tenantcontext(parser, token):
+    try:
+        tag_name, tenant_arg = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError(
+            '%r tag requires exactly one argument' % token.contents.split()[0]
+        )
+    nodelist = parser.parse(('endtenantcontext',))
+    parser.delete_first_token()
+    return TenantContextNode(tenant_arg, nodelist)
+
+
+class TenantContextNode(template.Node):
+    def __init__(self, tenant_arg, nodelist):
+        self.tenant_arg = template.Variable(tenant_arg)
+        self.nodelist = nodelist
+
+    def render(self, context):
+        try:
+            tenant = self.tenant_arg.resolve(context)
+        except template.VariableDoesNotExist:
+            raise template.TemplateSyntaxError(
+                'Unable to resolve %r' % self.tenant_arg.var
+            )
+        with tenant_context(tenant):
+            output = self.nodelist.render(context)
+        return output


### PR DESCRIPTION
This PR adds template tag equivalents for the `schema_context` and `tenant_context` utils. They can be used like this:

```html
{% tenantcontext mytenant %}
  {% some_tenant_specific_stuff %}
{% endtenantcontext %}
```

The use case is a dashboard view outside of a tenant context with aggregated data from different tenants. Gathering the data in the view is sometimes not enough because as soon as you try to access related data on a model (e.g. `{% for thing in my_instance.thing_set.all %}`) the database query will fail because it will execute within the public schema. 

If you consider this PR worth merging, I can add docs and tests.