### PR TITLE
Set URL conf for PUBLIC_SCHEMA_URLCONF to avoid URL pattern duplication

### DIFF
--- a/tenant_schemas/middleware.py
+++ b/tenant_schemas/middleware.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import DisallowedHost
 from django.db import connection
 from django.http import Http404
+from django.core.urlresolvers import set_urlconf
 from tenant_schemas.utils import (get_tenant_model, remove_www,
                                   get_public_schema_name)
 
@@ -65,6 +66,7 @@ class BaseTenantMiddleware(MIDDLEWARE_MIXIN):
         # Do we have a public-specific urlconf?
         if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():
             request.urlconf = settings.PUBLIC_SCHEMA_URLCONF
+            set_urlconf(request.urlconf)
 
 class TenantMiddleware(BaseTenantMiddleware):
     """


### PR DESCRIPTION
In the docs, it's said that if we want the user to be routed to different views when someone requests http://example.com/ and http://customer.example.com/, we can specify that URL pattern in the `PUBLIC_SCHEMA_URLCONF` file.

But if we want certain views to be available only when requested from public schema, currently we have to have those patterns in both `PUBLIC_SCHEMA_URLCONF` and `ROOT_URLCONF` files. And I had to then raise `django.views.defaults.page_not_found` on the `ROOT_URLCONF` pattern.

To fix this duplicate pattern issue, I had to add `set_urlconf(request.urlconf)` in the middleware.