### PR TITLE
fix: do not fail in initial migrations if PG_EXTRA_SEARCH_PATHS …

### DIFF
--- a/tenant_schemas/apps.py
+++ b/tenant_schemas/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig, apps
 from django.conf import settings
 from django.core.checks import Critical, Error, Warning, register
 from django.core.files.storage import default_storage
+from django.db import connection
 from tenant_schemas.storage import TenantStorageMixin
 from tenant_schemas.utils import get_public_schema_name, get_tenant_model
 
@@ -67,12 +68,15 @@ def best_practice(app_configs, **kwargs):
                 % get_public_schema_name()))
 
         # make sure no tenant schema is in settings.PG_EXTRA_SEARCH_PATHS
-        invalid_schemas = set(settings.PG_EXTRA_SEARCH_PATHS).intersection(
-            get_tenant_model().objects.all().values_list('schema_name', flat=True))
-        if invalid_schemas:
-            errors.append(Critical(
-                "Do not include tenant schemas (%s) on PG_EXTRA_SEARCH_PATHS."
-                % ", ".join(sorted(invalid_schemas))))
+        tenant_model = get_tenant_model()
+        # but avoid check during initial migration(s) when the table for tenant model is not created yet
+        if tenant_model._meta.db_table in connection.introspection.table_names():
+            invalid_schemas = set(settings.PG_EXTRA_SEARCH_PATHS).intersection(
+                tenant_model.objects.all().values_list('schema_name', flat=True))
+            if invalid_schemas:
+                errors.append(Critical(
+                    "Do not include tenant schemas (%s) on PG_EXTRA_SEARCH_PATHS."
+                    % ", ".join(sorted(invalid_schemas))))
 
     if not settings.SHARED_APPS:
         errors.append(


### PR DESCRIPTION
Do not fail in initial migrations if PG_EXTRA_SEARCH_PATHS is defined.

If we have empty database (like after DROP/CREATE DATABASE), the table for tenant model is not created yet and in old code all ./manage.py commands (like migrate_schemas) will fail. Worse: The error message is not very descriptive so it is not much easy find a workaround (which is temporary comment out PG_EXTRA_SEARCH_PATHS in settings).

This merge request should handle this so the code will run during initial migrations and no change in settings is needed.

In new code we just check if the (tenant) table exists in database. 

Best regards,
Mirek