### PR TITLE
docs: Fix simple typo, similiar -> similar

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -221,7 +221,7 @@ This is a context manager. Database queries performed inside it will be executed
 
 .. function:: tenant_context(tenant_object)
 
-This context manager is very similiar to the ``schema_context`` function,
+This context manager is very similar to the ``schema_context`` function,
 but it takes a tenant model object as the argument instead.
 
 .. code-block:: python


### PR DESCRIPTION
There is a small typo in docs/use.rst.

Should read `similar` rather than `similiar`.

