### PR TITLE
select the only existing schema by default in interactive tenant option

### DIFF
--- a/tenant_schemas/management/commands/__init__.py
+++ b/tenant_schemas/management/commands/__init__.py
@@ -116,22 +116,31 @@ https://django-tenant-schemas.readthedocs.io/en/latest/use.html#creating-a-tenan
         if options.get("schema_name"):
             tenant_schema = options["schema_name"]
         else:
-            while True:
-                tenant_schema = input("Enter Tenant Schema ('?' to list schemas): ")
-                if tenant_schema == "?":
-                    print(
-                        "\n".join(
-                            [
-                                "%s - %s" % (t.schema_name, t.domain_url,)
-                                for t in all_tenants
-                            ]
-                        )
+            if all_tenants.count() == 1:
+                only_tenant = all_tenants.first()
+                print(
+                    '"%s - %s" schema selected since it is the only existing schema.' % (
+                        only_tenant.schema_name, only_tenant.domain_url
                     )
-                else:
-                    break
+                )
+                tenant_schema = only_tenant.schema_name
+            else:
+                while True:
+                    tenant_schema = input("Enter Tenant Schema ('?' to list schemas): ")
+                    if tenant_schema == "?":
+                        print(
+                            "\n".join(
+                                [
+                                    "%s - %s" % (t.schema_name, t.domain_url,)
+                                    for t in all_tenants
+                                ]
+                            )
+                        )
+                    else:
+                        break
 
-        if tenant_schema not in [t.schema_name for t in all_tenants]:
-            raise CommandError("Invalid tenant schema, '%s'" % (tenant_schema,))
+                if tenant_schema not in [t.schema_name for t in all_tenants]:
+                    raise CommandError("Invalid tenant schema, '%s'" % (tenant_schema,))
 
         return TenantModel.objects.get(schema_name=tenant_schema)
 


### PR DESCRIPTION
Currently, even if there is only one scheme, user is shown with option to list schema and have to select it to proceed.
So this PR will, on interactive tenant option, select the only existing schema by default without user interaction if there is only one schema.