### PR TITLE
Fix error with Django 4

### DIFF
--- a/tenant_schemas/signals.py
+++ b/tenant_schemas/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-post_schema_sync = Signal(providing_args=['tenant'])
+post_schema_sync = Signal(['tenant'])
 post_schema_sync.__doc__ = """
 Sent after a tenant has been saved, its schema created and synced
 """


### PR DESCRIPTION
Django 4 no longer allows the Signal to come with the named providing_args argument but will work like this.