### PR TITLE
delaying import of ContentType until django is fully loaded

### DIFF
--- a/tenant_schemas/postgresql_backend/base.py
+++ b/tenant_schemas/postgresql_backend/base.py
@@ -75,7 +75,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         Main API method to current database schema,
         but it does not actually modify the db connection.
         """
-        is_init = not has_attr(self, 'schema_name')
+        is_init = not hasattr(self, 'schema_name')
         self.tenant = FakeTenant(schema_name=schema_name)
         self.schema_name = schema_name
         self.include_public_schema = include_public


### PR DESCRIPTION
I am attempting to upgrade to Django 3.2.14 and this is now causing a problem.
<img width="1268" alt="Screen Shot 2022-08-12 at 6 34 03 PM" src="https://user-images.githubusercontent.com/1323337/185226520-6b8fbb48-aec1-49d2-8cbd-258044ff770b.png">
It seems that it's trying to load the ContentType model before it's fully loaded. So I'm changing the code here such that the model is loaded as late as possible, after django is fully initialized.

Is this a good idea? Is there a better way?