### PR TITLE
Django 4 upgrade

### DIFF
--- a/tenant_schemas/management/commands/__init__.py
+++ b/tenant_schemas/management/commands/__init__.py
@@ -77,7 +77,6 @@ class BaseTenantCommand(BaseCommand):
         """
         Iterates a command over all registered schemata.
         """
-        arguments = ["schema_name", "skip_public"]
         if options["schema_name"]:
             # only run on a particular schema
             connection.set_schema_to_public()
@@ -85,7 +84,7 @@ class BaseTenantCommand(BaseCommand):
                 get_tenant_model().objects.get(schema_name=options["schema_name"]),
                 self.COMMAND_NAME,
                 *args,
-                **{k: v for k, v in options.items() if k not in arguments}
+                **options
             )
         else:
             for tenant in get_tenant_model().objects.all():
@@ -97,7 +96,7 @@ class BaseTenantCommand(BaseCommand):
                         tenant,
                         self.COMMAND_NAME,
                         *args,
-                        **{k: v for k, v in options.items() if k not in arguments}
+                        **options
                     )
 
 

--- a/tenant_schemas/postgresql_backend/introspection.py
+++ b/tenant_schemas/postgresql_backend/introspection.py
@@ -10,7 +10,7 @@ try:
     from django.db.models.indexes import Index
 except ImportError:
     Index = None
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 fields = FieldInfo._fields
 if 'default' not in fields:
@@ -213,9 +213,9 @@ class DatabaseSchemaIntrospection(BaseDatabaseIntrospection):
 
         return [
             FieldInfo(*(
-                (force_text(line[0]),) +
+                (force_str(line[0]),) +
                 line[1:6] +
-                (field_map[force_text(line[0])][0] == 'YES', field_map[force_text(line[0])][1])
+                (field_map[force_str(line[0])][0] == 'YES', field_map[force_str(line[0])][1])
             )) for line in cursor.description
         ]
 

--- a/tenant_schemas/signals.py
+++ b/tenant_schemas/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-post_schema_sync = Signal(providing_args=['tenant'])
+post_schema_sync = Signal(['tenant'])
 post_schema_sync.__doc__ = """
 Sent after a tenant has been saved, its schema created and synced
 """

--- a/tenant_schemas/test/client.py
+++ b/tenant_schemas/test/client.py
@@ -3,7 +3,7 @@ from tenant_schemas.middleware import TenantMiddleware
 
 
 class TenantRequestFactory(RequestFactory):
-    tm = TenantMiddleware()
+    tm = TenantMiddleware(lambda r:r)
 
     def __init__(self, tenant, **defaults):
         super(TenantRequestFactory, self).__init__(**defaults)
@@ -42,7 +42,7 @@ class TenantRequestFactory(RequestFactory):
 
 
 class TenantClient(Client):
-    tm = TenantMiddleware()
+    tm = TenantMiddleware(lambda r:r)
 
     def __init__(self, tenant, enforce_csrf_checks=False, **defaults):
         super(TenantClient, self).__init__(enforce_csrf_checks, **defaults)

--- a/tenant_schemas/tests/test_routes.py
+++ b/tenant_schemas/tests/test_routes.py
@@ -40,7 +40,7 @@ class RoutesTestCase(BaseTestCase):
     def setUp(self):
         super(RoutesTestCase, self).setUp()
         self.factory = RequestFactory()
-        self.tm = TenantMiddleware()
+        self.tm = TenantMiddleware(lambda r:r)
         self.dtm = DefaultTenantMiddleware()
 
         self.tenant_domain = "tenant.test.com"


### PR DESCRIPTION
* Fixed Django 4 syntax errors
* Fixed TypeError: \_\_init\_\_() missing 1 required positional argument: `get_response` (`TenantMiddleware`'s \_\_init\_\_())
* Fixed KeyError `schema_name` (`BaseTenantCommand`, in handle() function, the `schema_name` and `skip_public` were being removed from options. Removed this logic.)