### PR TITLE
Parse command through shlex to allow for passing custom parameters into tenant_command

### DIFF
--- a/tenant_schemas/management/commands/tenant_command.py
+++ b/tenant_schemas/management/commands/tenant_command.py
@@ -1,3 +1,5 @@
+import shlex
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connection
@@ -13,4 +15,8 @@ class Command(InteractiveTenantOption, BaseCommand):
             schema_name=schema_name, **options
         )
         connection.set_tenant(tenant)
-        call_command(command, *args, **options)
+
+        # allow passing a command as string including parameters
+        #  eg. `./manage.py tenant_command -s tenant "test_command --foo 123"`
+        parsed_command = shlex.split(command)
+        call_command(*parsed_command, *args, **options)


### PR DESCRIPTION
Currently, it's impossible to call into custom commands that have custom parameters.
This PR solves that by allowing to pass custom commands like:

```
./manage.py tenant_command -s tenant "test_command --foo 123"
```

should fix issue #645 